### PR TITLE
Chore/plug node info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,16 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "plug"
+version = "0.0.0"
+dependencies = [
+ "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "node-cli 2.0.0",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,16 +4729,6 @@ dependencies = [
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "substrate"
-version = "2.0.0"
-dependencies = [
- "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-cli 2.0.0",
- "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [[bin]]
-name = "substrate"
+name = "plug"
 path = "node/src/main.rs"
 
 [package]
-name = "substrate"
-version = "2.0.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+name = "plug"
+version = "0.0.0"
+authors = ["Plug Developers <admin@plug.team>", "Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -77,7 +77,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 /// Runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
-	impl_name: create_runtime_str!("substrate-node"),
+	impl_name: create_runtime_str!("plug-node"),
 	authoring_version: 10,
 	// Per convention: if the runtime behavior changes, increment spec_version
 	// and set impl_version to equal spec_version. If only runtime

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -45,13 +45,13 @@ impl cli::IntoExit for Exit {
 
 fn main() -> Result<(), cli::error::Error> {
 	let version = VersionInfo {
-		name: "Substrate Node",
+		name: "Plug Node",
 		commit: env!("VERGEN_SHA_SHORT"),
 		version: env!("CARGO_PKG_VERSION"),
-		executable_name: "substrate",
-		author: "Parity Technologies <admin@parity.io>",
-		description: "Generic substrate node",
-		support_url: "https://github.com/paritytech/substrate/issues/new",
+		executable_name: "plug",
+		author: "Plug Developers <admin@plug.team>",
+		description: "Generic plug node",
+		support_url: "https://github.com/plugblockchain/plug-blockchain/issues/new",
 	};
 
 	cli::run(std::env::args(), Exit, version)


### PR DESCRIPTION
Closes #5 

Binaries are now called plug instead of substrate. 

- Docker file updated 
- Docker build tested locally
- Toml files updated
- Version information updated
- Plug version set to 0.0.0 (to be updated when released)
