### PR TITLE
reinstate reward method, removed in upstream merge

### DIFF
--- a/srml/generic-asset/src/lib.rs
+++ b/srml/generic-asset/src/lib.rs
@@ -779,6 +779,11 @@ impl<T: Trait> Module<T> {
 		<FreeBalance<T>>::insert(asset_id, who, &balance);
 	}
 
+	#[cfg(test)]
+	pub fn _set_free_balance(asset_id: &T::AssetId, who: &T::AccountId, balance: T::Balance) {
+		<FreeBalance<T>>::insert(asset_id, who, &balance);
+	}
+
 	fn set_lock(
 		id: LockIdentifier,
 		who: &T::AccountId,

--- a/srml/generic-asset/src/lib.rs
+++ b/srml/generic-asset/src/lib.rs
@@ -646,6 +646,15 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
+	/// Adds `amount` to the free balance of `who`.
+	pub fn reward(asset_id: &T::AssetId, who: &T::AccountId, amount: T::Balance) -> Result {
+		let original_free_balance = Self::free_balance(asset_id, who);
+		let new_free_balance = original_free_balance + amount;
+		Self::set_free_balance(asset_id, who, new_free_balance);
+		<TotalIssuance<T>>::mutate(asset_id, |x| *x = x.saturating_add(amount));
+		Ok(())
+	}
+
 	/// Deducts up to `amount` from reserved balance of `who`. This function cannot fail.
 	///
 	/// As much funds up to `amount` will be deducted as possible. If the reserve balance of `who`


### PR DESCRIPTION
- Adding `reward()` method back, which was removed in the upstream merge.
- We need it for `cennzx-spot` module