### PR TITLE
break the main job into two

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ commands:
     steps:
       - run:
           command: cargo test --release --all
+          no_output_timeout: 30m
 jobs:
   build:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,28 @@ commands:
       - restore_cache:
           name: Restore target cache
           key: target-cache-{{ arch }}-{{ checksum ".circleci/RUST_VERSION" }}-{{ .Environment.CIRCLE_BRANCH }}
+  cargo-check:
+    steps:
+      - run:
+          name: Build
+          command: cargo check
+          no_output_timeout: 30m
+  cargo-build-test:
+    steps:
+      - run:
+          command: cargo test --no-run --release --all
+          no_output_timeout: 30m
+  cargo-run-test:
+    steps:
+      - run:
+          command: cargo test --release --all
 jobs:
   build:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - run: echo "successfully built and tested"
+  build-bin:
     machine:
       image: ubuntu-1604:201903-01
     resource_class: large
@@ -73,19 +93,32 @@ jobs:
       - install-rust
       - install-sccache
       - restore-cache
-      - run:
-          name: Build
-          command: |
-            cargo check
-          no_output_timeout: 30m
+      - cargo-check
       - save-cache
-      - run:
-          name: Build tests
-          command: |
-            cargo test --no-run --release --all
-          no_output_timeout: 30m
+  build-test-and-run:
+    machine:
+      image: ubuntu-1604:201903-01
+    resource_class: large
+    environment:
+      BASH_ENV: ~/.cargo/env
+      RUST_VERSION: stable-2019-11-07
+      RUSTC_WRAPPER: sccache
+      SCCACHE_CACHE_SIZE: 10G
+    steps:
+      - checkout
+      - install-rust
+      - install-sccache
+      - restore-cache
+      - cargo-build-test
       - save-cache
-      - run:
-          name: Run tests
-          command: |
-            cargo test --release --all
+      - cargo-run-test
+workflows:
+  version: 2
+  build-test-publish:
+    jobs:
+      - build-bin
+      - build-test-and-run
+      - build:
+          requires:
+            - build-bin
+            - build-test-and-run


### PR DESCRIPTION
Changes:
- break the main `build` job into `build-bin` and `build-test-and-run`
- use workflow to run them in parallel
- refactor some inline runs as commands
- add 30 min timeout period for running tests