### PR TITLE
add optional doughnut parameter to contract calls

### DIFF
--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -743,7 +743,7 @@ mod tests {
 				CheckedExtrinsic {
 					signed: Some((charlie(), signed_extra(1, 0))),
 					function: Call::Contracts(
-						contracts::Call::instantiate::<Runtime>(1 * DOLLARS, 10_000, transfer_ch, Vec::new())
+						contracts::Call::instantiate::<Runtime>(1 * DOLLARS, 10_000, transfer_ch, Vec::new(), None)
 					),
 				},
 				CheckedExtrinsic {
@@ -753,7 +753,8 @@ mod tests {
 							indices::address::Address::Id(addr.clone()),
 							10,
 							10_000,
-							vec![0x00, 0x01, 0x02, 0x03]
+							vec![0x00, 0x01, 0x02, 0x03],
+							None,
 						)
 					),
 				},

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -690,6 +690,7 @@ impl_runtime_apis! {
 				value,
 				gas_limit,
 				input_data,
+				None,
 			);
 			match exec_result {
 				Ok(v) => ContractExecResult::Success {

--- a/frame/contracts/src/doughnut_integration.rs
+++ b/frame/contracts/src/doughnut_integration.rs
@@ -1,0 +1,533 @@
+// Copyright 2019 Plug New Zealand Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused_must_use)]
+
+use crate::{
+	ComputeDispatchFee, ContractAddressFor, GenesisConfig, Module, Trait, TrieId, Schedule,
+	TrieIdGenerator,
+};
+use codec::{Encode, Decode};
+use primitives::storage::well_known_keys;
+use sp_runtime::{
+	Perbill, traits::{BlakeTwo256, Hash, IdentityLookup, PlugDoughnutApi},
+	testing::{Header, H256},
+};
+use support::{
+	assert_ok, assert_err, impl_outer_dispatch, impl_outer_event, impl_outer_origin,
+	parameter_types, StorageValue, traits::{Currency, Get}, weights::Weight,
+	additional_traits::DelegatedDispatchVerifier,
+};
+use std::cell::RefCell;
+use system::{self, RawOrigin};
+
+mod contract {
+	// Re-export contents of the root. This basically
+	// needs to give a name for the current crate.
+	// This hack is required for `impl_outer_event!`.
+	pub use super::super::*;
+}
+impl_outer_event! {
+	pub enum MetaEvent for Test {
+		balances<T>, contract<T>,
+	}
+}
+impl_outer_origin! {
+	pub enum Origin for Test { }
+}
+impl_outer_dispatch! {
+	pub enum Call for Test where origin: Origin {
+		balances::Balances,
+		contract::Contract,
+	}
+}
+
+thread_local! {
+	static EXISTENTIAL_DEPOSIT: RefCell<u64> = RefCell::new(0);
+	static TRANSFER_FEE: RefCell<u64> = RefCell::new(0);
+	static INSTANTIATION_FEE: RefCell<u64> = RefCell::new(0);
+	static BLOCK_GAS_LIMIT: RefCell<u64> = RefCell::new(0);
+}
+
+pub struct ExistentialDeposit;
+impl Get<u64> for ExistentialDeposit {
+	fn get() -> u64 { EXISTENTIAL_DEPOSIT.with(|v| *v.borrow()) }
+}
+
+pub struct TransferFee;
+impl Get<u64> for TransferFee {
+	fn get() -> u64 { TRANSFER_FEE.with(|v| *v.borrow()) }
+}
+
+pub struct CreationFee;
+impl Get<u64> for CreationFee {
+	fn get() -> u64 { INSTANTIATION_FEE.with(|v| *v.borrow()) }
+}
+
+pub struct BlockGasLimit;
+impl Get<u64> for BlockGasLimit {
+	fn get() -> u64 { BLOCK_GAS_LIMIT.with(|v| *v.borrow()) }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Test;
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+pub struct MockDoughnut {
+	verifiable: bool,
+}
+impl MockDoughnut {
+	fn new(verifiable: bool) -> Self {
+		Self {
+			verifiable,
+		}
+	}
+}
+impl PlugDoughnutApi for MockDoughnut {
+	type PublicKey = [u8; 32];
+	type Timestamp = u32;
+	type Signature = ();
+	fn holder(&self) -> Self::PublicKey { Default::default() }
+	fn issuer(&self) -> Self::PublicKey { Default::default() }
+	fn expiry(&self) -> Self::Timestamp { 0 }
+	fn not_before(&self) -> Self::Timestamp { 0 }
+	fn payload(&self) -> Vec<u8> { Vec::default() }
+	fn signature(&self) -> Self::Signature {}
+	fn signature_version(&self) -> u8 { 0 }
+	fn get_domain(&self, _domain: &str) -> Option<&[u8]> { None }
+}
+
+pub struct MockDispatchVerifier;
+impl DelegatedDispatchVerifier for MockDispatchVerifier {
+	type Doughnut = MockDoughnut;
+	type AccountId = u64;
+	const DOMAIN: &'static str = "";
+	fn verify_dispatch(
+		_doughnut: &Self::Doughnut,
+		_module: &str,
+		_method: &str,
+	) -> Result<(), &'static str> {
+		Ok(())
+	}
+	fn verify_runtime_to_contract_call(
+		_caller: &Self::AccountId,
+		_doughnut: &Self::Doughnut,
+		_contract_addr: &Self::AccountId,
+	) -> Result<(), &'static str> {
+		Ok(())
+	}
+	fn verify_contract_to_contract_call(
+		_caller: &Self::AccountId,
+		doughnut: &Self::Doughnut,
+		_contract_addr: &Self::AccountId,
+	) -> Result<(), &'static str> {
+		if doughnut.verifiable {
+			Ok(())
+		} else {
+			Err("Doughnut contract to contract call verification is not implemented for this domain")
+		}
+	}
+}
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl system::Trait for Test {
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Call = ();
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = MetaEvent;
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
+	type Doughnut = MockDoughnut;
+	type DelegatedDispatchVerifier = MockDispatchVerifier;
+}
+impl balances::Trait for Test {
+	type Balance = u64;
+	type OnFreeBalanceZero = Contract;
+	type OnNewAccount = ();
+	type Event = MetaEvent;
+	type DustRemoval = ();
+	type TransferPayment = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type TransferFee = TransferFee;
+	type CreationFee = CreationFee;
+}
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+impl timestamp::Trait for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+}
+parameter_types! {
+	pub const SignedClaimHandicap: u64 = 2;
+	pub const TombstoneDeposit: u64 = 16;
+	pub const StorageSizeOffset: u32 = 8;
+	pub const RentByteFee: u64 = 4;
+	pub const RentDepositOffset: u64 = 10_000;
+	pub const SurchargeReward: u64 = 150;
+	pub const TransactionBaseFee: u64 = 2;
+	pub const TransactionByteFee: u64 = 6;
+	pub const ContractFee: u64 = 21;
+	pub const CallBaseFee: u64 = 135;
+	pub const InstantiateBaseFee: u64 = 175;
+	pub const MaxDepth: u32 = 100;
+	pub const MaxValueSize: u32 = 16_384;
+}
+impl Trait for Test {
+	type Currency = Balances;
+	type Time = Timestamp;
+	type Randomness = Randomness;
+	type Call = Call;
+	type DetermineContractAddress = DummyContractAddressFor;
+	type Event = MetaEvent;
+	type ComputeDispatchFee = DummyComputeDispatchFee;
+	type TrieIdGenerator = DummyTrieIdGenerator;
+	type GasPayment = ();
+	type RentPayment = ();
+	type SignedClaimHandicap = SignedClaimHandicap;
+	type TombstoneDeposit = TombstoneDeposit;
+	type StorageSizeOffset = StorageSizeOffset;
+	type RentByteFee = RentByteFee;
+	type RentDepositOffset = RentDepositOffset;
+	type SurchargeReward = SurchargeReward;
+	type TransferFee = TransferFee;
+	type CreationFee = CreationFee;
+	type TransactionBaseFee = TransactionBaseFee;
+	type TransactionByteFee = TransactionByteFee;
+	type ContractFee = ContractFee;
+	type CallBaseFee = CallBaseFee;
+	type InstantiateBaseFee = InstantiateBaseFee;
+	type MaxDepth = MaxDepth;
+	type MaxValueSize = MaxValueSize;
+	type BlockGasLimit = BlockGasLimit;
+}
+
+type Balances = balances::Module<Test>;
+type Timestamp = timestamp::Module<Test>;
+type Contract = Module<Test>;
+type Randomness = randomness_collective_flip::Module<Test>;
+
+pub struct DummyContractAddressFor;
+impl ContractAddressFor<H256, u64> for DummyContractAddressFor {
+	fn contract_address_for(_code_hash: &H256, _data: &[u8], origin: &u64) -> u64 {
+		*origin + 1
+	}
+}
+
+pub struct DummyTrieIdGenerator;
+impl TrieIdGenerator<u64> for DummyTrieIdGenerator {
+	fn trie_id(account_id: &u64) -> TrieId {
+		let new_seed = super::AccountCounter::mutate(|v| {
+			*v = v.wrapping_add(1);
+			*v
+		});
+
+		// TODO: see https://github.com/paritytech/substrate/issues/2325
+		let mut res = vec![];
+		res.extend_from_slice(well_known_keys::CHILD_STORAGE_KEY_PREFIX);
+		res.extend_from_slice(b"default:");
+		res.extend_from_slice(&new_seed.to_le_bytes());
+		res.extend_from_slice(&account_id.to_le_bytes());
+		res
+	}
+}
+
+pub struct DummyComputeDispatchFee;
+impl ComputeDispatchFee<Call, u64> for DummyComputeDispatchFee {
+	fn compute_dispatch_fee(_call: &Call) -> u64 {
+		69
+	}
+}
+
+const ALICE: u64 = 1;
+const BOB: u64 = 2;
+
+pub struct ExtBuilder {
+	existential_deposit: u64,
+	gas_price: u64,
+	block_gas_limit: u64,
+	transfer_fee: u64,
+	instantiation_fee: u64,
+}
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self {
+			existential_deposit: 0,
+			gas_price: 2,
+			block_gas_limit: 100_000_000,
+			transfer_fee: 0,
+			instantiation_fee: 0,
+		}
+	}
+}
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn set_associated_consts(&self) {
+		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
+		TRANSFER_FEE.with(|v| *v.borrow_mut() = self.transfer_fee);
+		INSTANTIATION_FEE.with(|v| *v.borrow_mut() = self.instantiation_fee);
+		BLOCK_GAS_LIMIT.with(|v| *v.borrow_mut() = self.block_gas_limit);
+	}
+	pub fn build(self) -> runtime_io::TestExternalities {
+		self.set_associated_consts();
+		let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		balances::GenesisConfig::<Test> {
+			balances: vec![],
+			vesting: vec![],
+		}.assimilate_storage(&mut t).unwrap();
+		GenesisConfig::<Test> {
+			current_schedule: Schedule {
+				enable_println: true,
+				..Default::default()
+			},
+			gas_price: self.gas_price,
+		}.assimilate_storage(&mut t).unwrap();
+		runtime_io::TestExternalities::new(t)
+	}
+}
+
+/// Generate Wasm binary and code hash from wabt source.
+fn compile_module<T>(wabt_module: &str)
+	-> Result<(Vec<u8>, <T::Hashing as Hash>::Output), wabt::Error>
+	where T: system::Trait
+{
+	let wasm = wabt::wat2wasm(wabt_module)?;
+	let code_hash = T::Hashing::hash(&wasm);
+	Ok((wasm, code_hash))
+}
+
+const CODE_RETURN_WITH_DATA: &str = r#"
+(module
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+	(import "env" "ext_scratch_write" (func $ext_scratch_write (param i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	;; Deploy routine is the same as call.
+	(func (export "deploy") (result i32)
+		(call $call)
+	)
+
+	;; Call reads the first 4 bytes (LE) as the exit status and returns the rest as output data.
+	(func $call (export "call") (result i32)
+		(local $buf_size i32)
+		(local $exit_status i32)
+
+		;; Find out the size of the scratch buffer
+		(set_local $buf_size (call $ext_scratch_size))
+
+		;; Copy scratch buffer into this contract memory.
+		(call $ext_scratch_read
+			(i32.const 0)			;; The pointer where to store the scratch buffer contents,
+			(i32.const 0)			;; Offset from the start of the scratch buffer.
+			(get_local $buf_size)	;; Count of bytes to copy.
+		)
+
+		;; Copy all but the first 4 bytes of the input data as the output data.
+		(call $ext_scratch_write
+			(i32.const 4)	;; Pointer to the data to return.
+			(i32.sub		;; Count of bytes to copy.
+				(get_local $buf_size)
+				(i32.const 4)
+			)
+		)
+
+		;; Return the first 4 bytes of the input data as the exit status.
+		(i32.load (i32.const 0))
+	)
+)
+"#;
+
+const CODE_CALLER_CONTRACT: &str = r#"
+(module
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	(func $assert (param i32)
+		(block $ok
+			(br_if $ok
+				(get_local 0)
+			)
+			(unreachable)
+		)
+	)
+
+	(func (export "deploy"))
+
+	(func (export "call")
+		;; Declare local variables.
+		(local $exit_code i32)
+
+		;; Copy code hash from scratch buffer into this contract's memory.
+		(call $ext_scratch_read
+			(i32.const 24)		;; The pointer where to store the scratch buffer contents,
+			(i32.const 0)		;; Offset from the start of the scratch buffer.
+			(i32.const 32)		;; Count of bytes to copy.
+		)
+
+		;; Deploy the contract successfully.
+		(set_local $exit_code
+			(call $ext_instantiate
+				(i32.const 24)	;; Pointer to the code hash.
+				(i32.const 32)	;; Length of the code hash.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+
+		;; Check for success exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x00))
+		)
+
+		;; Call the contract successfully.
+		(set_local $exit_code
+			(call $ext_call
+				(i32.const 16)	;; Pointer to "callee" address.
+				(i32.const 8)	;; Length of "callee" address.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+		;; Check for success exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x00))
+		)
+	)
+
+	(data (i32.const 0) "\00\80")
+	(data (i32.const 8) "\00\11\22\33\44\55\66\77")
+)
+"#;
+
+#[test]
+fn contract_to_contract_call_executes_with_verifiable_doughnut() {
+	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_RETURN_WITH_DATA).unwrap();
+	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_CALLER_CONTRACT).unwrap();
+	let verifiable_doughnut = MockDoughnut::new(true);
+	let delegated_origin = RawOrigin::from((Some(ALICE), Some(verifiable_doughnut.clone())));
+
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, callee_wasm));
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, caller_wasm));
+		assert_ok!(Contract::instantiate(
+			delegated_origin.clone().into(),
+			100_000,
+			100_000,
+			caller_code_hash.into(),
+			vec![],
+			Some(verifiable_doughnut.clone()),
+		));
+		// Call BOB contract, which attempts to instantiate and call the callee contract
+		assert_ok!(Contract::call(
+			delegated_origin.into(),
+			BOB,
+			0,
+			200_000,
+			callee_code_hash.as_ref().to_vec(),
+			Some(verifiable_doughnut),
+		));
+	});
+}
+
+#[test]
+fn contract_to_contract_call_executes_without_doughnut() {
+	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_RETURN_WITH_DATA).unwrap();
+	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_CALLER_CONTRACT).unwrap();
+	let delegated_origin = RawOrigin::from((Some(ALICE), None));
+
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, callee_wasm));
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, caller_wasm));
+		assert_ok!(Contract::instantiate(
+			delegated_origin.clone().into(),
+			100_000,
+			100_000,
+			caller_code_hash.into(),
+			vec![],
+			None,
+		));
+		// Call BOB contract, which attempts to instantiate and call the callee contract
+		assert_ok!(Contract::call(
+			delegated_origin.into(),
+			BOB,
+			0,
+			200_000,
+			callee_code_hash.as_ref().to_vec(),
+			None,
+		));
+	});
+}
+
+#[test]
+fn contract_to_contract_call_returns_error_with_unverifiable_doughnut() {
+	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_RETURN_WITH_DATA).unwrap();
+	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_CALLER_CONTRACT).unwrap();
+	let unverifiable_doughnut = MockDoughnut::new(false);
+	let delegated_origin = RawOrigin::from((Some(ALICE), Some(unverifiable_doughnut.clone())));
+
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, callee_wasm));
+		assert_ok!(Contract::put_code(delegated_origin.clone().into(), 100_000, caller_wasm));
+		assert_ok!(Contract::instantiate(
+			delegated_origin.clone().into(),
+			100_000,
+			100_000,
+			caller_code_hash.into(),
+			vec![],
+			Some(unverifiable_doughnut.clone()),
+		));
+		// Call BOB contract, which attempts to instantiate and call the callee contract
+		assert_err!(
+			Contract::call(
+				delegated_origin.into(),
+				BOB,
+				0,
+				200_000,
+				callee_code_hash.as_ref().to_vec(),
+				Some(unverifiable_doughnut),
+			),
+			"during execution", // due to $exit_code being non-zero
+		);
+	});
+}

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -28,6 +28,7 @@ use support::{
 };
 
 pub type AccountIdOf<T> = <T as system::Trait>::AccountId;
+pub type DoughnutOf<T> = <T as system::Trait>::Doughnut;
 pub type CallOf<T> = <T as Trait>::Call;
 pub type MomentOf<T> = <<T as Trait>::Time as Time>::Moment;
 pub type SeedOf<T> = <T as system::Trait>::Hash;
@@ -147,6 +148,9 @@ pub trait Ext {
 
 	/// Returns a reference to the account id of the current contract.
 	fn address(&self) -> &AccountIdOf<Self::T>;
+
+	/// Returns the doughnut of the current contract.
+	fn doughnut(&self) -> Option<DoughnutOf<Self::T>>;
 
 	/// Returns the balance of the current contract.
 	///
@@ -758,6 +762,10 @@ where
 
 	fn address(&self) -> &T::AccountId {
 		&self.ctx.self_account
+	}
+
+	fn doughnut(&self) -> Option<DoughnutOf<T>> {
+		self.ctx.doughnut.clone()
 	}
 
 	fn caller(&self) -> &T::AccountId {

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -150,7 +150,7 @@ pub trait Ext {
 	fn address(&self) -> &AccountIdOf<Self::T>;
 
 	/// Returns the doughnut of the current contract.
-	fn doughnut(&self) -> Option<DoughnutOf<Self::T>>;
+	fn doughnut(&self) -> Option<&DoughnutOf<Self::T>>;
 
 	/// Returns the balance of the current contract.
 	///
@@ -288,7 +288,7 @@ pub struct ExecutionContext<'a, T: Trait + 'a, V, L> {
 	pub timestamp: MomentOf<T>,
 	pub block_number: T::BlockNumber,
 	pub origin: T::AccountId,
-	pub doughnut: Option<T::Doughnut>,
+	pub doughnut: Option<&'a T::Doughnut>,
 }
 
 impl<'a, T, E, V, L> ExecutionContext<'a, T, V, L>
@@ -301,7 +301,7 @@ where
 	///
 	/// The specified `origin` address will be used as `sender` for. The `origin` must be a regular
 	/// account (not a contract).
-	pub fn top_level(origin: T::AccountId, cfg: &'a Config<T>, vm: &'a V, loader: &'a L, doughnut: Option<T::Doughnut>) -> Self {
+	pub fn top_level(origin: T::AccountId, cfg: &'a Config<T>, vm: &'a V, loader: &'a L, doughnut: Option<&'a T::Doughnut>) -> Self {
 		ExecutionContext {
 			parent: None,
 			self_trie_id: None,
@@ -315,7 +315,7 @@ where
 			timestamp: T::Time::now(),
 			block_number: <system::Module<T>>::block_number(),
 			origin: origin.clone(),
-			doughnut: doughnut.clone(),
+			doughnut: doughnut,
 		}
 	}
 
@@ -335,7 +335,7 @@ where
 			timestamp: self.timestamp.clone(),
 			block_number: self.block_number.clone(),
 			origin: self.origin.clone(),
-			doughnut: self.doughnut.clone(),
+			doughnut: self.doughnut,
 		}
 	}
 
@@ -764,8 +764,8 @@ where
 		&self.ctx.self_account
 	}
 
-	fn doughnut(&self) -> Option<DoughnutOf<T>> {
-		self.ctx.doughnut.clone()
+	fn doughnut(&self) -> Option<&DoughnutOf<T>> {
+		self.ctx.doughnut
 	}
 
 	fn caller(&self) -> &T::AccountId {

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -284,6 +284,7 @@ pub struct ExecutionContext<'a, T: Trait + 'a, V, L> {
 	pub timestamp: MomentOf<T>,
 	pub block_number: T::BlockNumber,
 	pub origin: T::AccountId,
+	pub doughnut: Option<T::Doughnut>,
 }
 
 impl<'a, T, E, V, L> ExecutionContext<'a, T, V, L>
@@ -296,7 +297,7 @@ where
 	///
 	/// The specified `origin` address will be used as `sender` for. The `origin` must be a regular
 	/// account (not a contract).
-	pub fn top_level(origin: T::AccountId, cfg: &'a Config<T>, vm: &'a V, loader: &'a L) -> Self {
+	pub fn top_level(origin: T::AccountId, cfg: &'a Config<T>, vm: &'a V, loader: &'a L, doughnut: Option<T::Doughnut>) -> Self {
 		ExecutionContext {
 			parent: None,
 			self_trie_id: None,
@@ -309,7 +310,8 @@ where
 			loader: &loader,
 			timestamp: T::Time::now(),
 			block_number: <system::Module<T>>::block_number(),
-			origin: origin.clone()
+			origin: origin.clone(),
+			doughnut: doughnut.clone(),
 		}
 	}
 
@@ -328,7 +330,8 @@ where
 			loader: self.loader,
 			timestamp: self.timestamp.clone(),
 			block_number: self.block_number.clone(),
-			origin: self.origin.clone()
+			origin: self.origin.clone(),
+			doughnut: self.doughnut.clone(),
 		}
 	}
 
@@ -959,7 +962,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, exec_ch).unwrap();
 
 			assert_matches!(
@@ -976,22 +979,22 @@ mod tests {
 		ExtBuilder::default().build().execute_with(|| {
 			let value = Default::default();
 			let vm = MockVm::new();
-			let loader = MockLoader::empty();   
+			let loader = MockLoader::empty();
 		   	let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);	 
-			
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
+
 			assert_eq!(*ctx.new_call_context(BOB, value).origin(), ALICE);
 		});
 	}
-	
+
 	#[test]
 	fn origin_is_correct_for_nested_calls() {
 		ExtBuilder::default().build().execute_with(|| {
 			let value = Default::default();
 			let vm = MockVm::new();
-			let loader = MockLoader::empty();   
+			let loader = MockLoader::empty();
 		   	let cfg = Config::preload();
-			let ctx = ExecutionContext::top_level(BOB, &cfg, &vm, &loader);	 
+			let ctx = ExecutionContext::top_level(BOB, &cfg, &vm, &loader, None);
 			let mut nested = ctx.nested(ALICE, None);
 
 			assert_eq!(*nested.new_call_context(CHARLIE, value).origin(), BOB);
@@ -1008,7 +1011,7 @@ mod tests {
 			let vm = MockVm::new();
 			let loader = MockLoader::empty();
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 0);
 
@@ -1028,7 +1031,7 @@ mod tests {
 
 			let vm = MockVm::new();
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 
 			ctx.overlay.set_balance(&origin, 100);
 
@@ -1054,7 +1057,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 0);
 
@@ -1086,7 +1089,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 0);
@@ -1116,7 +1119,7 @@ mod tests {
 			let vm = MockVm::new();
 			let loader = MockLoader::empty();
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 0);
 
@@ -1142,7 +1145,7 @@ mod tests {
 			let vm = MockVm::new();
 			let loader = MockLoader::empty();
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 15);
 
@@ -1170,7 +1173,7 @@ mod tests {
 
 			let vm = MockVm::new();
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 15);
@@ -1204,7 +1207,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&origin, 0);
 
 			let result = ctx.call(
@@ -1238,7 +1241,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 
 			let result = ctx.call(
@@ -1269,7 +1272,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 
 			let result = ctx.call(
@@ -1297,7 +1300,7 @@ mod tests {
 		// This one tests passing the input data into a contract via call.
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, input_data_ch).unwrap();
 
 			let result = ctx.call(
@@ -1322,7 +1325,7 @@ mod tests {
 		// This one tests passing the input data into a contract via instantiate.
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 
 			let result = ctx.instantiate(
 				0,
@@ -1366,7 +1369,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, recurse_ch).unwrap();
 
 			let result = ctx.call(
@@ -1411,7 +1414,7 @@ mod tests {
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 
-			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&dest, bob_ch).unwrap();
 			ctx.overlay.instantiate_contract(&CHARLIE, charlie_ch).unwrap();
 
@@ -1452,7 +1455,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.instantiate_contract(&BOB, bob_ch).unwrap();
 			ctx.overlay.instantiate_contract(&CHARLIE, charlie_ch).unwrap();
 
@@ -1476,7 +1479,7 @@ mod tests {
 
 		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 
 			assert_matches!(
 				ctx.instantiate(
@@ -1501,7 +1504,7 @@ mod tests {
 
 		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&ALICE, 1000);
 
 			let instantiated_contract_address = assert_matches!(
@@ -1541,7 +1544,7 @@ mod tests {
 
 		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&ALICE, 1000);
 
 			let instantiated_contract_address = assert_matches!(
@@ -1586,7 +1589,7 @@ mod tests {
 
 		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&ALICE, 1000);
 			ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
@@ -1645,7 +1648,7 @@ mod tests {
 
 		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 			ctx.overlay.set_balance(&ALICE, 1000);
 			ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
@@ -1678,7 +1681,7 @@ mod tests {
 
 		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
-			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader, None);
 
 			let result = ctx.instantiate(
 				0,

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -98,6 +98,8 @@ mod rent;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod doughnut_integration;
 
 use crate::exec::ExecutionContext;
 use crate::account_db::{AccountDb, DirectAccountDb};

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -720,7 +720,7 @@ impl<T: Trait> Module<T> {
 		let cfg = Config::preload();
 		let vm = WasmVm::new(&cfg.schedule);
 		let loader = WasmLoader::new(&cfg.schedule);
-		let mut ctx = ExecutionContext::top_level(origin.clone(), &cfg, &vm, &loader, doughnut);
+		let mut ctx = ExecutionContext::top_level(origin.clone(), &cfg, &vm, &loader, doughnut.as_ref());
 
 		let result = func(&mut ctx, &mut gas_meter);
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -572,12 +572,13 @@ decl_module! {
 			dest: <T::Lookup as StaticLookup>::Source,
 			#[compact] value: BalanceOf<T>,
 			#[compact] gas_limit: Gas,
-			data: Vec<u8>
+			data: Vec<u8>,
+			doughnut: Option<T::Doughnut>,
 		) -> Result {
 			let dest = T::Lookup::lookup(dest)?;
 			let origin = ensure_verified_contract_call::<T>(origin, &dest)?;
 
-			Self::bare_call(origin, dest, value, gas_limit, data)
+			Self::bare_call(origin, dest, value, gas_limit, data, doughnut)
 				.map(|_| ())
 				.map_err(|e| e.reason)
 		}
@@ -597,11 +598,12 @@ decl_module! {
 			#[compact] endowment: BalanceOf<T>,
 			#[compact] gas_limit: Gas,
 			code_hash: CodeHash<T>,
-			data: Vec<u8>
+			data: Vec<u8>,
+			doughnut: Option<T::Doughnut>,
 		) -> Result {
 			let origin = ensure_signed(origin)?;
 
-			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
+			Self::execute_wasm(origin, gas_limit, doughnut, |ctx, gas_meter| {
 				ctx.instantiate(endowment, gas_meter, &code_hash, data)
 					.map(|(_address, output)| output)
 			})
@@ -670,8 +672,9 @@ impl<T: Trait> Module<T> {
 		value: BalanceOf<T>,
 		gas_limit: Gas,
 		input_data: Vec<u8>,
+		doughnut: Option<T::Doughnut>,
 	) -> ExecResult {
-		Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
+		Self::execute_wasm(origin, gas_limit, doughnut, |ctx, gas_meter| {
 			ctx.call(dest, value, gas_meter, input_data)
 		})
 	}
@@ -700,6 +703,7 @@ impl<T: Trait> Module<T> {
 	fn execute_wasm(
 		origin: T::AccountId,
 		gas_limit: Gas,
+		doughnut: Option<T::Doughnut>,
 		func: impl FnOnce(&mut ExecutionContext<T, WasmVm, WasmLoader>, &mut GasMeter<T>) -> ExecResult
 	) -> ExecResult {
 		// Pay for the gas upfront.
@@ -716,7 +720,7 @@ impl<T: Trait> Module<T> {
 		let cfg = Config::preload();
 		let vm = WasmVm::new(&cfg.schedule);
 		let loader = WasmLoader::new(&cfg.schedule);
-		let mut ctx = ExecutionContext::top_level(origin.clone(), &cfg, &vm, &loader);
+		let mut ctx = ExecutionContext::top_level(origin.clone(), &cfg, &vm, &loader, doughnut);
 
 		let result = func(&mut ctx, &mut gas_meter);
 
@@ -1055,8 +1059,8 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckBlockGasLimit<T> {
 			Call::claim_surcharge(_, _) | Call::update_schedule(_) =>
 				Ok(ValidTransaction::default()),
 			Call::put_code(gas_limit, _)
-				| Call::call(_, _, gas_limit, _)
-				| Call::instantiate(_, gas_limit, _, _)
+				| Call::call(_, _, gas_limit, _, _)
+				| Call::instantiate(_, gas_limit, _, _, _)
 			=> {
 				// Check if the specified amount of gas is available in the current block.
 				// This cannot underflow since `gas_spent` is never greater than `T::BlockGasLimit`.

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -114,8 +114,8 @@ impl system::Trait for Test {
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
 	type Version = ();
-    type Doughnut = ();
-    type DelegatedDispatchVerifier = ();
+	type Doughnut = ();
+	type DelegatedDispatchVerifier = ();
 }
 impl balances::Trait for Test {
 	type Balance = u64;

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -305,7 +305,7 @@ fn refunds_unused_gas() {
 	ExtBuilder::default().gas_price(2).build().execute_with(|| {
 		Balances::deposit_creating(&ALICE, 100_000_000);
 
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, Vec::new()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, Vec::new(), None));
 
 		// 2 * 135 - gas price multiplied by the call base fee.
 		assert_eq!(Balances::free_balance(&ALICE), 100_000_000 - (2 * 135));
@@ -423,6 +423,7 @@ fn instantiate_and_call_and_deposit_event() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		);
 
 		assert_eq!(System::events(), vec![
@@ -517,6 +518,7 @@ fn dispatch_call() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		assert_ok!(Contract::call(
@@ -525,6 +527,7 @@ fn dispatch_call() {
 			0,
 			100_000,
 			vec![],
+			None,
 		));
 
 		assert_eq!(System::events(), vec![
@@ -635,6 +638,7 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Call the newly instantiated contract. The contract is expected to dispatch a call
@@ -646,6 +650,7 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 				0,
 				100_000,
 				vec![],
+				None,
 			),
 			"during execution"
 		);
@@ -843,16 +848,17 @@ fn storage_size() {
 			Origin::signed(ALICE),
 			30_000,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
 
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::set_storage_4_byte()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::set_storage_4_byte(), None));
 		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4 + 4);
 
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::remove_storage_4_byte()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::remove_storage_4_byte(), None));
 		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
 	});
@@ -870,7 +876,8 @@ fn deduct_blocks() {
 			Origin::signed(ALICE),
 			30_000,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 
 		// Check creation
@@ -881,7 +888,7 @@ fn deduct_blocks() {
 		System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
 		// Trigger rent through call
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None));
 
 		// Check result
 		let rent = (8 + 4 - 3) // storage size = size_offset + deploy_set_storage - deposit_offset
@@ -896,7 +903,7 @@ fn deduct_blocks() {
 		System::initialize(&12, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
 		// Trigger rent through call
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None));
 
 		// Check result
 		let rent_2 = (8 + 4 - 2) // storage size = size_offset + deploy_set_storage - deposit_offset
@@ -908,7 +915,7 @@ fn deduct_blocks() {
 		assert_eq!(Balances::free_balance(BOB), 30_000 - rent - rent_2);
 
 		// Second call on same block should have no effect on rent
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None));
 
 		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.rent_allowance, 1_000 - rent - rent_2);
@@ -921,7 +928,7 @@ fn deduct_blocks() {
 fn call_contract_removals() {
 	removals(|| {
 		// Call on already-removed account might fail, and this is fine.
-		Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null());
+		Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None);
 		true
 	});
 }
@@ -964,7 +971,8 @@ fn claim_surcharge(blocks: u64, trigger_call: impl Fn() -> bool, removes: bool) 
 			Origin::signed(ALICE),
 			100,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 
 		// Advance blocks
@@ -997,7 +1005,8 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			Origin::signed(ALICE),
 			100,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 
 		let subsistence_threshold = 50 /*existential_deposit*/ + 16 /*tombstone_deposit*/;
@@ -1033,7 +1042,8 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			Origin::signed(ALICE),
 			1_000,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(100u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(100u32).encode(), // rent allowance
+			None,
 		));
 
 		// Trigger rent must have no effect
@@ -1068,7 +1078,8 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			Origin::signed(ALICE),
 			50+Balances::minimum_balance(),
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 
 		// Trigger rent must have no effect
@@ -1077,7 +1088,7 @@ fn removals(trigger_call: impl Fn() -> bool) {
 		assert_eq!(Balances::free_balance(&BOB), 50 + Balances::minimum_balance());
 
 		// Transfer funds
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::transfer()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::transfer(), None));
 		assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
 		assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
 
@@ -1112,24 +1123,25 @@ fn call_removed_contract() {
 			Origin::signed(ALICE),
 			100,
 			100_000, code_hash.into(),
-			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+			<Test as balances::Trait>::Balance::from(1_000u32).encode(), // rent allowance
+			None,
 		));
 
 		// Calling contract should succeed.
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None));
 
 		// Advance blocks
 		System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
 		// Calling contract should remove contract and fail.
 		assert_err!(
-			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None),
 			"contract has been evicted"
 		);
 
  		// Subsequent contract calls should also fail.
 		assert_err!(
-			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None),
 			"contract has been evicted"
 		);
 	})
@@ -1199,6 +1211,7 @@ fn default_rent_allowance_on_instantiate() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Check creation
@@ -1209,7 +1222,7 @@ fn default_rent_allowance_on_instantiate() {
 		System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
 		// Trigger rent through call
-		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None));
 
 		// Check contract is still alive
 		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive();
@@ -1335,7 +1348,8 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			30_000,
 			100_000,
 			set_rent_code_hash.into(),
-			<Test as balances::Trait>::Balance::from(0u32).encode()
+			<Test as balances::Trait>::Balance::from(0u32).encode(),
+			None,
 		));
 
 		// Check if `BOB` was created successfully and that the rent allowance is
@@ -1347,8 +1361,9 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			assert_ok!(Contract::call(
 				Origin::signed(ALICE),
 				BOB, 0, 100_000,
-				call::set_storage_4_byte())
-			);
+				call::set_storage_4_byte(),
+				None,
+			));
 		}
 
 		// Advance 4 blocks, to the 5th.
@@ -1357,7 +1372,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 		// Call `BOB`, which makes it pay rent. Since the rent allowance is set to 0
 		// we expect that it will get removed leaving tombstone.
 		assert_err!(
-			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null(), None),
 			"contract has been evicted"
 		);
 		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
@@ -1372,7 +1387,8 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			30_000,
 			100_000,
 			restoration_code_hash.into(),
-			<Test as balances::Trait>::Balance::from(0u32).encode()
+			<Test as balances::Trait>::Balance::from(0u32).encode(),
+			None,
 		));
 
 		// Before performing a call to `DJANGO` save its original trie id.
@@ -1392,6 +1408,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			0,
 			100_000,
 			vec![],
+			None,
 		));
 
 		if test_different_storage || test_restore_to_with_dirty_storage {
@@ -1496,6 +1513,7 @@ fn storage_max_value_limit() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Check creation
@@ -1509,6 +1527,7 @@ fn storage_max_value_limit() {
 			0,
 			100_000,
 			Encode::encode(&self::MaxValueSize::get()),
+			None,
 		));
 
 		// Call contract with too large a storage value.
@@ -1519,6 +1538,7 @@ fn storage_max_value_limit() {
 				0,
 				100_000,
 				Encode::encode(&(self::MaxValueSize::get() + 1)),
+				None,
 			),
 			"during execution"
 		);
@@ -1862,6 +1882,7 @@ fn deploy_and_call_other_contract() {
 			100_000,
 			caller_code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Call BOB contract, which attempts to instantiate and call the callee contract and
@@ -1872,6 +1893,7 @@ fn deploy_and_call_other_contract() {
 			0,
 			200_000,
 			callee_code_hash.as_ref().to_vec(),
+			None,
 		));
 	});
 }
@@ -1989,6 +2011,7 @@ fn self_destruct_by_draining_balance() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Check that the BOB contract has been instantiated.
@@ -2004,6 +2027,7 @@ fn self_destruct_by_draining_balance() {
 			0,
 			100_000,
 			vec![],
+			None,
 		));
 
 		// Check that BOB is now dead.
@@ -2025,6 +2049,7 @@ fn cannot_self_destruct_while_live() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 
 		// Check that the BOB contract has been instantiated.
@@ -2042,6 +2067,7 @@ fn cannot_self_destruct_while_live() {
 				0,
 				100_000,
 				vec![0],
+				None,
 			),
 			"during execution"
 		);
@@ -2227,6 +2253,7 @@ fn destroy_contract_and_transfer_funds() {
 			100_000,
 			caller_code_hash.into(),
 			callee_code_hash.as_ref().to_vec(),
+			None,
 		));
 
 		// Check that the CHARLIE contract has been instantiated.
@@ -2242,6 +2269,7 @@ fn destroy_contract_and_transfer_funds() {
 			0,
 			100_000,
 			CHARLIE.encode(),
+			None,
 		));
 
 		// Check that CHARLIE has moved on to the great beyond (ie. died).
@@ -2322,6 +2350,7 @@ fn cannot_self_destruct_in_constructor() {
 				100_000,
 				code_hash.into(),
 				vec![],
+				None,
 			),
 			"insufficient remaining balance"
 		);
@@ -2439,6 +2468,7 @@ fn get_runtime_storage() {
 			100_000,
 			code_hash.into(),
 			vec![],
+			None,
 		));
 		assert_ok!(Contract::call(
 			Origin::signed(ALICE),
@@ -2446,6 +2476,7 @@ fn get_runtime_storage() {
 			0,
 			100_000,
 			vec![],
+			None,
 		));
 	});
 }

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -909,49 +909,6 @@ mod tests {
 		).unwrap();
 	}
 
-	/// calls `ext_doughnut`, loads the doughnut from the scratch buffer and
-	/// compares it with the constant 1.
-	const CODE_DOUGHNUT: &str = r#"
-(module
-	(import "env" "ext_doughnut" (func $ext_doughnut (result i32)))
-	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
-	(import "env" "memory" (memory 1 1))
-
-	(func $assert (param i32)
-		(block $ok
-			(br_if $ok
-				(get_local 0)
-			)
-			(unreachable)
-		)
-	)
-
-	;; Load a storage value into the scratch buf.
-	(func (export "call")
-		;; assert $ext_scratch_size == 8
-		(call $assert
-			(i32.eq
-				(call $ext_doughnut)
-				(i32.const 0)
-			)
-		)
-	)
-
-	(func (export "deploy"))
-)
-"#;
-
-	#[test]
-	fn doughnut() {
-		let _ = execute(
-			CODE_DOUGHNUT,
-			vec![],
-			MockExt::default(),
-			&mut GasMeter::with_limit(50_000, 1),
-		).unwrap();
-	}
-
 	const CODE_BALANCE: &str = r#"
 (module
 	(import "env" "ext_balance" (func $ext_balance))

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -286,6 +286,9 @@ mod tests {
 		fn address(&self) -> &u64 {
 			&69
 		}
+		fn doughnut(&self) -> Option<()> {
+			Some(())
+		}
 		fn balance(&self) -> u64 {
 			228
 		}
@@ -389,6 +392,9 @@ mod tests {
 		}
 		fn address(&self) -> &u64 {
 			(**self).address()
+		}
+		fn doughnut(&self) -> Option<()> {
+			(**self).doughnut()
 		}
 		fn balance(&self) -> u64 {
 			(**self).balance()
@@ -897,6 +903,49 @@ mod tests {
 	fn address() {
 		let _ = execute(
 			CODE_ADDRESS,
+			vec![],
+			MockExt::default(),
+			&mut GasMeter::with_limit(50_000, 1),
+		).unwrap();
+	}
+
+	/// calls `ext_doughnut`, loads the doughnut from the scratch buffer and
+	/// compares it with the constant 1.
+	const CODE_DOUGHNUT: &str = r#"
+(module
+	(import "env" "ext_doughnut" (func $ext_doughnut (result i32)))
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	(func $assert (param i32)
+		(block $ok
+			(br_if $ok
+				(get_local 0)
+			)
+			(unreachable)
+		)
+	)
+
+	;; Load a storage value into the scratch buf.
+	(func (export "call")
+		;; assert $ext_scratch_size == 8
+		(call $assert
+			(i32.eq
+				(call $ext_doughnut)
+				(i32.const 0)
+			)
+		)
+	)
+
+	(func (export "deploy"))
+)
+"#;
+
+	#[test]
+	fn doughnut() {
+		let _ = execute(
+			CODE_DOUGHNUT,
 			vec![],
 			MockExt::default(),
 			&mut GasMeter::with_limit(50_000, 1),

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -286,8 +286,8 @@ mod tests {
 		fn address(&self) -> &u64 {
 			&69
 		}
-		fn doughnut(&self) -> Option<()> {
-			Some(())
+		fn doughnut(&self) -> Option<&()> {
+			Some(&())
 		}
 		fn balance(&self) -> u64 {
 			228
@@ -393,7 +393,7 @@ mod tests {
 		fn address(&self) -> &u64 {
 			(**self).address()
 		}
-		fn doughnut(&self) -> Option<()> {
+		fn doughnut(&self) -> Option<&()> {
 			(**self).doughnut()
 		}
 		fn balance(&self) -> u64 {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -560,18 +560,6 @@ define_env!(Env, <E: Ext>,
 		Ok(())
 	},
 
-	// Stores the doughnut of the current contract into the scratch buffer.
-	// Returns 0 if doughnut is present, otherwise 1.
-	ext_doughnut(ctx) -> u32 => {
-		ctx.scratch_buf.clear();
-		if let Some(doughnut) = ctx.ext.doughnut() {
-			doughnut.encode_to(&mut ctx.scratch_buf);
-			Ok(0)
-		} else {
-			Ok(1)
-		}
-	},
-
 	// Stores the gas price for the current transaction into the scratch buffer.
 	//
 	// The data is encoded as T::Balance. The current contents of the scratch buffer are overwritten.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -560,6 +560,18 @@ define_env!(Env, <E: Ext>,
 		Ok(())
 	},
 
+	// Stores the doughnut of the current contract into the scratch buffer.
+	// Returns 0 if doughnut is present, otherwise 1.
+	ext_doughnut(ctx) -> u32 => {
+		ctx.scratch_buf.clear();
+		if let Some(doughnut) = ctx.ext.doughnut() {
+			doughnut.encode_to(&mut ctx.scratch_buf);
+			Ok(0)
+		} else {
+			Ok(1)
+		}
+	},
+
 	// Stores the gas price for the current transaction into the scratch buffer.
 	//
 	// The data is encoded as T::Balance. The current contents of the scratch buffer are overwritten.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -30,6 +30,8 @@ use rstd::mem;
 use codec::{Decode, Encode};
 use sp_runtime::traits::{Bounded, SaturatedConversion};
 
+type DelegatedDispatchVerifierOf<E> = <<E as Ext>::T as system::Trait>::DelegatedDispatchVerifier;
+
 /// The value returned from ext_call and ext_instantiate contract external functions if the call or
 /// instantiation traps. This value is chosen as if the execution does not trap, the return value
 /// will always be an 8-bit integer, so 0x0100 is the smallest value that could not be returned.
@@ -389,9 +391,8 @@ define_env!(Env, <E: Ext>,
 			read_sandbox_memory_as(ctx, value_ptr, value_len)?;
 
 		if let Some(doughnut) = ctx.ext.doughnut() {
-			type DelegatedDispatchVerifierOf<E> = <<E as Ext>::T as system::Trait>::DelegatedDispatchVerifier;
 			DelegatedDispatchVerifierOf::<E>::verify_contract_to_contract_call(
-				&callee,
+				&ctx.ext.origin(),
 				doughnut,
 				&callee,
 			).map_err(|_| sandbox::HostError)?;


### PR DESCRIPTION
Changes:
- [x] ExecutionContext has optional doughnut field
    - added optional doughnut param to methods where needed
    - for tests and node/runtime, None is used as doughnut for now
- [x]  Expose execution context doughnut via new doughnut() method on the Ext trait
- [x] Add contract-to-contract hook using Ext::doughnut()

Closes #33 