### PR TITLE
bump up rust to the latest stable release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
     resource_class: large
     environment:
       BASH_ENV: ~/.cargo/env
-      RUST_VERSION: stable-2019-11-07
+      RUST_VERSION: stable-2019-12-19
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
     steps:
@@ -102,7 +102,7 @@ jobs:
     resource_class: large
     environment:
       BASH_ENV: ~/.cargo/env
-      RUST_VERSION: stable-2019-11-07
+      RUST_VERSION: stable-2019-12-19
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
     steps:

--- a/client/src/light/backend.rs
+++ b/client/src/light/backend.rs
@@ -61,7 +61,7 @@ pub struct ImportOperation<Block: BlockT, S, H: Hasher> {
 	finalized_blocks: Vec<BlockId<Block>>,
 	set_head: Option<BlockId<Block>>,
 	storage_update: Option<InMemoryState<H>>,
-	_phantom: ::std::marker::PhantomData<(S)>,
+	_phantom: ::std::marker::PhantomData<S>,
 }
 
 /// Either in-memory genesis state, or locally-unavailable state.


### PR DESCRIPTION
Bumping up Rust to the latest stable 1.40.0 (which introduces #[non_exhaustive] attribute required for some ui tests).

https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#whats-in-1.40.0-stable