### PR TITLE
Feature/32 contract permissioning

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -37,6 +37,7 @@ pub use support::{
 	StorageValue, construct_runtime, parameter_types,
 	traits::Randomness,
 	weights::Weight,
+	additional_traits::DummyDispatchVerifier,
 };
 
 /// An index to a block.
@@ -157,7 +158,7 @@ impl system::Trait for Runtime {
 	/// The runtime proof of delegation type (Doughnut)
 	type Doughnut = PlugDoughnut<Doughnut, Runtime>;
 	/// The runtime delegated dispatch verifier
-	type DelegatedDispatchVerifier = ();
+	type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
 	/// Maximum weight of each block.
 	type MaximumBlockWeight = MaximumBlockWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.

--- a/bin/node-template/runtime/src/template.rs
+++ b/bin/node-template/runtime/src/template.rs
@@ -79,7 +79,7 @@ mod tests {
 		},
 		Perbill,
 	};
-	use support::{impl_outer_origin, assert_ok, parameter_types, weights::Weight};
+	use support::{impl_outer_origin, assert_ok, parameter_types, weights::Weight, additional_traits::DummyDispatchVerifier};
 
 	impl_outer_origin! {
 		pub enum Origin for Test {}
@@ -109,7 +109,7 @@ mod tests {
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type Doughnut = PlugDoughnut<TestDoughnut, Test>;
-		type DelegatedDispatchVerifier = ();
+		type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
 		testing::{Header, UintAuthorityId}, traits::{ConvertInto, IdentityLookup, OpaqueKeys},
 		Perbill, KeyTypeId,
 	};
-	use support::{impl_outer_origin, parameter_types, weights::Weight};
+	use support::{impl_outer_origin, parameter_types, weights::Weight, additional_traits::DummyDispatchVerifier};
 
 	type AuthorityDiscovery = Module<Test>;
 	type SessionIndex = u32;
@@ -165,7 +165,7 @@ mod tests {
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
 		type Doughnut = ();
-		type DelegatedDispatchVerifier = ();
+		type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
 		type Version = ();
 	}
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -169,6 +169,7 @@ use support::{
 		WithdrawReason, WithdrawReasons, LockIdentifier, LockableCurrency, ExistenceRequirement,
 		Imbalance, SignedImbalance, ReservableCurrency, Get, VestingCurrency,
 	},
+	additional_traits::DummyDispatchVerifier,
 	weights::SimpleDispatchInfo,
 	dispatch::Result,
 };
@@ -794,7 +795,7 @@ impl<T: Subtrait<I>, I: Instance> system::Trait for ElevatedTrait<T, I> {
 	type Event = ();
 	type BlockHashCount = T::BlockHashCount;
 	type Doughnut = T::Doughnut;
-	type DelegatedDispatchVerifier = ();
+	type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
 	type MaximumBlockWeight = T::MaximumBlockWeight;
 	type MaximumBlockLength = T::MaximumBlockLength;
 	type AvailableBlockRatio = T::AvailableBlockRatio;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -126,7 +126,7 @@ use support::{
 	weights::DispatchInfo,
 };
 use support::traits::{OnFreeBalanceZero, OnUnbalanced, Currency, Get, Time, Randomness};
-use system::{ensure_signed, RawOrigin, ensure_root, ensure_verified};
+use system::{ensure_signed, RawOrigin, ensure_root, ensure_verified_contract_call};
 use primitives::storage::well_known_keys::CHILD_STORAGE_KEY_PREFIX;
 
 pub type CodeHash<T> = <T as system::Trait>::Hash;
@@ -575,7 +575,7 @@ decl_module! {
 			data: Vec<u8>
 		) -> Result {
 			let dest = T::Lookup::lookup(dest)?;
-			let origin = ensure_verified::<T>(origin, &dest)?;
+			let origin = ensure_verified_contract_call::<T>(origin, &dest)?;
 
 			Self::bare_call(origin, dest, value, gas_limit, data)
 				.map(|_| ())

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -126,7 +126,7 @@ use support::{
 	weights::DispatchInfo,
 };
 use support::traits::{OnFreeBalanceZero, OnUnbalanced, Currency, Get, Time, Randomness};
-use system::{ensure_signed, RawOrigin, ensure_root};
+use system::{ensure_signed, RawOrigin, ensure_root, ensure_verified};
 use primitives::storage::well_known_keys::CHILD_STORAGE_KEY_PREFIX;
 
 pub type CodeHash<T> = <T as system::Trait>::Hash;
@@ -574,8 +574,8 @@ decl_module! {
 			#[compact] gas_limit: Gas,
 			data: Vec<u8>
 		) -> Result {
-			let origin = ensure_signed(origin)?;
 			let dest = T::Lookup::lookup(dest)?;
+			let origin = ensure_verified::<T>(origin, &dest)?;
 
 			Self::bare_call(origin, dest, value, gas_limit, data)
 				.map(|_| ())

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -114,8 +114,8 @@ impl system::Trait for Test {
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
 	type Version = ();
-        type Doughnut = ();
-        type DelegatedDispatchVerifier = ();
+    type Doughnut = ();
+    type DelegatedDispatchVerifier = ();
 }
 impl balances::Trait for Test {
 	type Balance = u64;

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -53,8 +53,8 @@ impl system::Trait for Test {
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();
-        type Doughnut = ();
-        type DelegatedDispatchVerifier = ();
+	type Doughnut = ();
+    type DelegatedDispatchVerifier = ();
 }
 
 parameter_types! {

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -394,7 +394,7 @@ mod tests {
 	// We aren't testing doughnut verification here just return `Ok(())`
 	pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
 	impl<T: system::Trait> DelegatedDispatchVerifier for MockDelegatedDispatchVerifier<T> {
-		type Doughnut = T::Doughnut;		
+		type Doughnut = T::Doughnut;
 		type AccountId = T::AccountId;
 		const DOMAIN: &'static str = "";
 		fn verify_dispatch(

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -394,6 +394,7 @@ mod tests {
 	// We aren't testing doughnut verification here just return `Ok(())`
 	pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
 	impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
+		type AccountId = <Self as system::Trait>::AccountId;
 		const DOMAIN: &'static str = "";
 		fn verify_dispatch(
 			_doughnut: &T::Doughnut,

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -393,7 +393,8 @@ mod tests {
 
 	// We aren't testing doughnut verification here just return `Ok(())`
 	pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
-	impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
+	impl<T: system::Trait> DelegatedDispatchVerifier for MockDelegatedDispatchVerifier<T> {
+		type Doughnut = T::Doughnut;		
 		type AccountId = T::AccountId;
 		const DOMAIN: &'static str = "";
 		fn verify_dispatch(

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -394,7 +394,7 @@ mod tests {
 	// We aren't testing doughnut verification here just return `Ok(())`
 	pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
 	impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
-		type AccountId = <Self as system::Trait>::AccountId;
+		type AccountId = T::AccountId;
 		const DOMAIN: &'static str = "";
 		fn verify_dispatch(
 			_doughnut: &T::Doughnut,

--- a/frame/executive/tests/doughnut_integration.rs
+++ b/frame/executive/tests/doughnut_integration.rs
@@ -59,6 +59,7 @@ impl_outer_dispatch! {
 
 pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
 impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
+	type AccountId = <Self as system::Trait>::AccountId;
 	const DOMAIN: &'static str = "test";
 	fn verify_dispatch(
 		doughnut: &T::Doughnut,

--- a/frame/executive/tests/doughnut_integration.rs
+++ b/frame/executive/tests/doughnut_integration.rs
@@ -59,7 +59,7 @@ impl_outer_dispatch! {
 
 pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
 impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
-	type AccountId = <Self as system::Trait>::AccountId;
+	type AccountId = T::AccountId;
 	const DOMAIN: &'static str = "test";
 	fn verify_dispatch(
 		doughnut: &T::Doughnut,

--- a/frame/executive/tests/doughnut_integration.rs
+++ b/frame/executive/tests/doughnut_integration.rs
@@ -58,7 +58,8 @@ impl_outer_dispatch! {
 }
 
 pub struct MockDelegatedDispatchVerifier<T: system::Trait>(rstd::marker::PhantomData<T>);
-impl<T: system::Trait> DelegatedDispatchVerifier<T::Doughnut> for MockDelegatedDispatchVerifier<T> {
+impl<T: system::Trait> DelegatedDispatchVerifier for MockDelegatedDispatchVerifier<T> {
+	type Doughnut = T::Doughnut;
 	type AccountId = T::AccountId;
 	const DOMAIN: &'static str = "test";
 	fn verify_dispatch(

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -168,6 +168,7 @@ use support::{
 		Currency, ExistenceRequirement, Imbalance, LockIdentifier, LockableCurrency, ReservableCurrency,
 		SignedImbalance, UpdateBalanceOutcome, WithdrawReason, WithdrawReasons, TryDrop,
 	},
+	additional_traits::DummyDispatchVerifier,
 	Parameter, StorageMap,
 };
 use system::{ensure_signed, ensure_root};
@@ -1083,7 +1084,7 @@ impl<T: Subtrait> system::Trait for ElevatedTrait<T> {
 	type AvailableBlockRatio = T::AvailableBlockRatio;
 	type BlockHashCount = T::BlockHashCount;
 	type Doughnut = T::Doughnut;
-	type DelegatedDispatchVerifier = ();
+	type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
 	type Version = T::Version;
 }
 impl<T: Subtrait> Trait for ElevatedTrait<T> {

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -812,8 +812,8 @@ mod tests {
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type Version = ();
-                type DelegatedDispatchVerifier = ();
-                type Doughnut = ();
+        type DelegatedDispatchVerifier = ();
+        type Doughnut = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -88,8 +88,8 @@ impl system::Trait for Runtime {
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();
-        type Doughnut = ();
-        type DelegatedDispatchVerifier = ();
+    type Doughnut = ();
+    type DelegatedDispatchVerifier = ();
 }
 
 impl Trait for Runtime {

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -70,8 +70,8 @@ impl system::Trait for Test {
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();
-        type Doughnut = ();
-        type DelegatedDispatchVerifier = ();
+    type Doughnut = ();
+    type DelegatedDispatchVerifier = ();
 }
 
 impl balances::Trait for Test {

--- a/frame/support/src/additional_traits.rs
+++ b/frame/support/src/additional_traits.rs
@@ -52,6 +52,8 @@ impl<T, U> ChargeFee<T> for DummyChargeFee<T, U> {
 /// The `verify()` hook is injected into every module/method on the runtime.
 /// When a doughnut proof is included along with a transaction, `verify` will be invoked just before executing method logic.
 pub trait DelegatedDispatchVerifier<Doughnut> {
+	type AccountId;
+
 	/// The doughnut permission domain it verifies
 	const DOMAIN: &'static str;
 	/// Check the doughnut authorizes a dispatched call to `module` and `method` for this domain
@@ -60,10 +62,21 @@ pub trait DelegatedDispatchVerifier<Doughnut> {
 		module: &str,
 		method: &str,
 	) -> Result<(), &'static str>;
+
+	/// Check the doughnut authorizes a dispatched call from runtime to the specified contract address for this domain.
+	fn verify_runtime_to_contract_dispatch(caller: &Self::AccountId, doughnut: &Doughnut, contract_addr: &Self::AccountId) -> Result<(), &'static str> {
+		Err("Doughnut runtime to contract dispatch verification is not implemented for this domain")
+	}
+	
+	/// Check the doughnut authorizes a dispatched call from a contract to another contract with the specified addresses for this domain.
+	fn verify_contract_to_contract_dispatch(caller: &Self::AccountId, doughnut: &Doughnut, contract_addr: &Self::AccountId) -> Result<(), &'static str> {
+		Err("Doughnut contract to contract dispatch verification is not implemented for this domain")
+	}
 }
 
 /// A dummy implementation for when dispatch verifiaction is not needed
 impl<Doughnut> DelegatedDispatchVerifier<Doughnut> for () {
+	type AccountId = u64;
 	const DOMAIN: &'static str = "";
 	fn verify_dispatch(_: &Doughnut, _: &str, _: &str) -> Result<(), &'static str> {
 		Ok(())

--- a/frame/support/src/additional_traits.rs
+++ b/frame/support/src/additional_traits.rs
@@ -64,12 +64,12 @@ pub trait DelegatedDispatchVerifier<Doughnut> {
 	) -> Result<(), &'static str>;
 
 	/// Check the doughnut authorizes a dispatched call from runtime to the specified contract address for this domain.
-	fn verify_runtime_to_contract_dispatch(caller: &Self::AccountId, doughnut: &Doughnut, contract_addr: &Self::AccountId) -> Result<(), &'static str> {
+	fn verify_runtime_to_contract_dispatch(_caller: &Self::AccountId, _doughnut: &Doughnut, _contract_addr: &Self::AccountId) -> Result<(), &'static str> {
 		Err("Doughnut runtime to contract dispatch verification is not implemented for this domain")
 	}
 	
 	/// Check the doughnut authorizes a dispatched call from a contract to another contract with the specified addresses for this domain.
-	fn verify_contract_to_contract_dispatch(caller: &Self::AccountId, doughnut: &Doughnut, contract_addr: &Self::AccountId) -> Result<(), &'static str> {
+	fn verify_contract_to_contract_dispatch(_caller: &Self::AccountId, _doughnut: &Doughnut, _contract_addr: &Self::AccountId) -> Result<(), &'static str> {
 		Err("Doughnut contract to contract dispatch verification is not implemented for this domain")
 	}
 }

--- a/frame/support/src/additional_traits.rs
+++ b/frame/support/src/additional_traits.rs
@@ -58,15 +58,15 @@ pub trait DelegatedDispatchVerifier {
 
     /// The doughnut permission domain it verifies
     const DOMAIN: &'static str;
-	
+
 	/// Check the doughnut authorizes a dispatched call to `module` and `method` for this domain
     fn verify_dispatch(
         _doughnut: &Self::Doughnut,
         _module: &str,
         _method: &str,
     ) -> Result<(), &'static str> {
-		Err("Doughnut call to module and method verification not implemented for this domain")	
-	}
+		Err("Doughnut call to module and method verification not implemented for this domain")
+    }
 
     /// Check the doughnut authorizes a dispatched call from runtime to the specified contract address for this domain.
     fn verify_runtime_to_contract_call(

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1917,7 +1917,7 @@ mod tests {
 		pub trait Trait {
 			type AccountId;
 			type Doughnut;
-			type DelegatedDispatchVerifier: DelegatedDispatchVerifier<()>;
+			type DelegatedDispatchVerifier: DelegatedDispatchVerifier<Doughnut = ()>;
 		}
 
 		pub fn ensure_root<R>(_: R) -> Result {

--- a/frame/support/src/metadata.rs
+++ b/frame/support/src/metadata.rs
@@ -249,7 +249,7 @@ mod tests {
 			type BlockNumber: From<u32> + Encode;
 			type SomeValue: Get<u32>;
 			type Doughnut;
-			type DelegatedDispatchVerifier: DelegatedDispatchVerifier<()>;
+			type DelegatedDispatchVerifier: DelegatedDispatchVerifier<Doughnut = ()>;
 		}
 
 		decl_module! {

--- a/frame/support/test/tests/reserved_keyword/on_initialize.rs
+++ b/frame/support/test/tests/reserved_keyword/on_initialize.rs
@@ -18,7 +18,7 @@ macro_rules! reserved {
 
 					pub trait Trait {
 						type Doughnut: DoughnutApi;
-						type DelegatedDispatchVerifier: DelegatedDispatchVerifier<()>;
+						type DelegatedDispatchVerifier: DelegatedDispatchVerifier<Doughnut = ()>;
 					}
 
 					pub fn ensure_root<R>(_: R) -> Result {

--- a/frame/support/test/tests/system.rs
+++ b/frame/support/test/tests/system.rs
@@ -8,7 +8,7 @@ pub trait Trait: 'static + Eq + Clone {
 	type Hash;
 	type AccountId: Encode + EncodeLike + Decode;
 	type Event: From<Event>;
-	type DelegatedDispatchVerifier: DelegatedDispatchVerifierT<()>;
+	type DelegatedDispatchVerifier: DelegatedDispatchVerifierT<Doughnut = ()>;
 	type Doughnut;
 }
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -533,12 +533,11 @@ pub fn ensure_signed<OuterOrigin, AccountId, Doughnut>(o: OuterOrigin) -> Result
 /// Ensure that 'origin' represents a signed or delegated extrinsic. If 'origin' is a delegated one, ensure that doughnut verifies
 /// the issuers's privilage to call dest (destination contract). Return `Ok` with the account id of the issuer who signed the extrinsic
 /// or delegated it, otherwise `Err`.
-pub fn ensure_verified<T: Trait>(
+pub fn ensure_verified_contract_call<T: Trait>(
     origin: T::Origin,
     dest: &T::AccountId,
 ) -> Result<T::AccountId, &'static str> {
     match origin.into() {
-        // Assuming the delegation proof has been validated, a `RawOrigin::Delegated` should also be considered a valid `RawOrigin::Signed`
         Ok(RawOrigin::Signed(t)) => Ok(t),
         Ok(RawOrigin::Delegated(t, doughnut)) => {
             if let Err(msg) =

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -210,7 +210,7 @@ pub trait Trait: 'static + Eq + Clone {
 	type Doughnut: Parameter + Member + DoughnutApi;
 
 	/// A type which verifies a doughnut in order to dispatch a `Call` with delegated authority
-	type DelegatedDispatchVerifier: DelegatedDispatchVerifierT<Self::Doughnut>;
+	type DelegatedDispatchVerifier: DelegatedDispatchVerifierT<Doughnut = Self::Doughnut, AccountId = Self::AccountId>;
 
 	/// The maximum weight of a block.
 	type MaximumBlockWeight: Get<Weight>;
@@ -528,6 +528,29 @@ pub fn ensure_signed<OuterOrigin, AccountId, Doughnut>(o: OuterOrigin) -> Result
 		Ok(RawOrigin::Signed(t)) | Ok(RawOrigin::Delegated(t, _)) => Ok(t),
 		_ => Err("bad origin: expected to be a signed origin"),
 	}
+}
+
+/// Ensure that 'origin' represents a signed or delegated extrinsic. If 'origin' is a delegated one, ensure that doughnut verifies
+/// the issuers's privilage to call dest (destination contract). Return `Ok` with the account id of the issuer who signed the extrinsic
+/// or delegated it, otherwise `Err`.
+pub fn ensure_verified<T: Trait>(
+    origin: T::Origin,
+    dest: &T::AccountId,
+) -> Result<T::AccountId, &'static str> {
+    match origin.into() {
+        // Assuming the delegation proof has been validated, a `RawOrigin::Delegated` should also be considered a valid `RawOrigin::Signed`
+        Ok(RawOrigin::Signed(t)) => Ok(t),
+        Ok(RawOrigin::Delegated(t, doughnut)) => {
+            if let Err(msg) =
+                T::DelegatedDispatchVerifier::verify_runtime_to_contract_call(&t, &doughnut, dest)
+            {
+                Err(msg)
+            } else {
+                Ok(t)
+            }
+        }
+        _ => Err("bad origin: expected to be a signed origin"),
+    }
 }
 
 /// Ensure that the origin `o` represents the root. Returns `Ok` or an `Err` otherwise.

--- a/prml/doughnut/src/lib.rs
+++ b/prml/doughnut/src/lib.rs
@@ -63,7 +63,8 @@ where
 /// It verifies that a doughnut allows execution of a module+method combination
 pub struct PlugDoughnutDispatcher<Runtime: DoughnutRuntime>(rstd::marker::PhantomData<Runtime>);
 
-impl<Runtime: DoughnutRuntime> DelegatedDispatchVerifier<Runtime::Doughnut> for PlugDoughnutDispatcher<Runtime> {
+impl<Runtime: DoughnutRuntime> DelegatedDispatchVerifier for PlugDoughnutDispatcher<Runtime> {
+	type Doughnut = Runtime::Doughnut;
 	type AccountId = Runtime::AccountId;
 	const DOMAIN: &'static str = "plug";
 	/// Verify a Doughnut proof authorizes method dispatch given some input parameters

--- a/prml/doughnut/src/lib.rs
+++ b/prml/doughnut/src/lib.rs
@@ -64,6 +64,7 @@ where
 pub struct PlugDoughnutDispatcher<Runtime: DoughnutRuntime>(rstd::marker::PhantomData<Runtime>);
 
 impl<Runtime: DoughnutRuntime> DelegatedDispatchVerifier<Runtime::Doughnut> for PlugDoughnutDispatcher<Runtime> {
+	type AccountId = Runtime::AccountId;
 	const DOMAIN: &'static str = "plug";
 	/// Verify a Doughnut proof authorizes method dispatch given some input parameters
 	fn verify_dispatch(


### PR DESCRIPTION
Ensure delegated calls are verified by the doughnut.

Also:
- Make it explicit that DelegatedDispatchVerifier of any 'Trait' would be made out of the same doughnut and account id types used in that 'Trait'. 
- Replace "()" as the dummy DelegatedDispatchVerifier by a clear generic type DummyDispatchVerifier which is consistent with the non-dummy case. 
- Moreover make doughnut an associated type rather than a generic parameter for DelegatedDispatchVerifier the same as it is for AccountId.
