### PR TITLE
Better doughnut validation codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,6 +4873,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-std",
 ]

--- a/frame/executive/tests/doughnut_integration.rs
+++ b/frame/executive/tests/doughnut_integration.rs
@@ -339,7 +339,7 @@ fn delegated_dispatch_fails_when_extrinsic_signer_is_not_doughnut_holder() {
 		));
 
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(171))));
+		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(180))));
 	});
 }
 
@@ -384,7 +384,7 @@ fn delegated_dispatch_fails_when_doughnut_is_expired() {
 		));
 
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(171))));
+		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(181))));
 	});
 }
 
@@ -427,7 +427,7 @@ fn delegated_dispatch_fails_when_doughnut_is_premature() {
 			Digest::default(),
 		));
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(171))));
+		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(182))));
 	});
 }
 

--- a/prml/doughnut/Cargo.toml
+++ b/prml/doughnut/Cargo.toml
@@ -14,6 +14,7 @@ frame-support = { default-features = false, path = "../../frame/support" }
 
 [dev-dependencies]
 sp-io ={ default-features = false, path = "../../primitives/io" }
+sp-keyring = { default-features = false, path = "../../primitives/keyring" }
 
 [features]
 default = ["std"]

--- a/prml/doughnut/src/constants.rs
+++ b/prml/doughnut/src/constants.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Plug New Zealand Limited
+// This file is part of Plug.
+
+// Plug is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Plug is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Plug. If not, see <http://www.gnu.org/licenses/>.
+
+//! Plug Doughnut Constants
+
+pub (crate) mod error_code {
+	//! Plug Doughnut Error Code Constants
+	pub const VERIFY_INVALID: u8 = 170;
+	pub const VERIFY_UNSUPPORTED_VERSION: u8 = 171;
+	pub const VERIFY_BAD_SIGNATURE_FORMAT: u8 = 172;
+	pub const VERIFY_BAD_PUBLIC_KEY_FORMAT: u8 = 173;
+	pub const VALIDATION_HOLDER_SIGNER_IDENTITY_MISMATCH: u8 = 180;
+	pub const VALIDATION_EXPIRED: u8 = 181;
+	pub const VALIDATION_PREMATURE: u8 = 182;
+	pub const VALIDATION_CONVERSION: u8 = 183;
+}

--- a/prml/doughnut/src/lib.rs
+++ b/prml/doughnut/src/lib.rs
@@ -1,16 +1,19 @@
-// Copyright 2019 Plug New Zealand Limited
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019-2020 Plug New Zealand Limited
+// This file is part of Plug.
+
+// Plug is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Plug is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Plug. If not, see <http://www.gnu.org/licenses/>.
+
 
 //! A collection of doughnut traits and srtucts which provide doughnut integartion for a plug runtime.
 //! This includes validation and signature verification and type conversions.
@@ -24,6 +27,7 @@ use frame_support::Parameter;
 use frame_support::additional_traits::DelegatedDispatchVerifier;
 use frame_support::traits::Time;
 
+mod constants;
 mod impls;
 
 // TODO: This should eventually become a super trait for `system::Trait` so that all doughnut functionality may be moved here


### PR DESCRIPTION
Masking the validation errors is making testing tricky from the API.
This PR changes this to use specific error codes on doughnut validation.


Codes are:
- 17X for signature errors
- 18X for semantic validation errors

Also:
- improved tests to use keyring module
- update license header to GPL 3