### PR TITLE
Attestation Module Audit Updates (BT-161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,6 +4951,8 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/prml/attestation/Cargo.toml
+++ b/prml/attestation/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-core = { default-features = false, path = "../../primitives/core" }
+sp-io = { default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 frame-support = { default-features = false, path = "../../frame/support" }
 frame-system = { default-features = false, path = "../../frame/system" }
 
@@ -15,6 +17,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"sp-core/std",
+	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -146,23 +146,23 @@ impl<T: Trait> Module<T> {
         topic: AttestationTopic,
         value: AttestationValue,
     ) {
-        let is_update: bool = <Topics<T>>::get((holder.clone(), issuer.clone())).contains(&topic);
-
         <Issuers<T>>::mutate(&holder, |issuers| {
             if !issuers.contains(&issuer) {
                 issuers.push(issuer.clone())
             }
         });
 
+        let topic_exists: bool = <Topics<T>>::get((holder.clone(), issuer.clone())).contains(&topic);
+
         <Topics<T>>::mutate((holder.clone(), issuer.clone()), |topics| {
-            if !topics.contains(&topic) {
+            if !topic_exists {
                 topics.push(topic)
             }
         });
 
         <Values<T>>::insert((holder.clone(), issuer.clone(), topic), value);
 
-        if is_update {
+        if topic_exists {
             Self::deposit_event(RawEvent::ClaimUpdated(holder, issuer, topic, value));
         } else {
             Self::deposit_event(RawEvent::ClaimCreated(holder, issuer, topic, value));

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -53,7 +53,9 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
 		fn deposit_event() = default;
 
-		/// Create a new claim
+		/// Create or update an existing claim
+		/// The `issuer` of the claim comes from the extrinsic `origin`
+		/// The `topic` and `value` are both U256 which can hold any 32-byte encoded data.
 		pub fn set_claim(origin, holder: T::AccountId, topic: AttestationTopic, value: AttestationValue) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 
@@ -62,6 +64,7 @@ decl_module! {
 		}
 
 		/// Remove a claim, only the original issuer can remove a claim
+		/// If the `issuer` has not yet issued a claim of `topic`, this function will return error.
 		pub fn remove_claim(origin, holder: T::AccountId, topic: AttestationTopic) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -57,7 +57,7 @@ decl_module! {
 		pub fn set_claim(origin, holder: T::AccountId, topic: AttestationTopic, value: AttestationValue) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 
-			Self::create_or_update_claim(holder, issuer, topic, value)?;
+			Self::create_or_update_claim(holder, issuer, topic, value);
 			Ok(())
 		}
 
@@ -138,7 +138,7 @@ impl<T: Trait> Module<T> {
 		issuer: T::AccountId,
 		topic: AttestationTopic,
 		value: AttestationValue,
-	) -> DispatchResult {
+	) {
 		let is_update : bool = Self::get_topics((holder.clone(), issuer.clone())).contains(&topic);
 
 		<Issuers<T>>::mutate(&holder, |issuers| {
@@ -161,8 +161,6 @@ impl<T: Trait> Module<T> {
 		else {
 			Self::deposit_event(RawEvent::ClaimSet(holder, issuer, topic, value));
 		}
-
-		Ok(())
 	}
 }
 

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -44,6 +44,7 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 use sp_core::uint::U256;
+use sp_runtime::traits::Zero;
 
 pub trait Trait: frame_system::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -82,7 +83,7 @@ decl_module! {
 
             <Topics<T>>::mutate((holder.clone(), issuer.clone()),|topics| topics.retain(|vec_topic| *vec_topic != topic));
 
-            let remove_issuer = <Topics<T>>::get((holder.clone(), issuer.clone())).len() == 0;
+            let remove_issuer = <Topics<T>>::get((holder.clone(), issuer.clone())).len().is_zero();
             if remove_issuer {
                 <Issuers<T>>::mutate(&holder, |issuers| {
                     issuers.retain(|vec_issuer| *vec_issuer != issuer.clone())
@@ -152,7 +153,8 @@ impl<T: Trait> Module<T> {
             }
         });
 
-        let topic_exists: bool = <Topics<T>>::get((holder.clone(), issuer.clone())).contains(&topic);
+        let topic_exists: bool =
+            <Topics<T>>::get((holder.clone(), issuer.clone())).contains(&topic);
 
         <Topics<T>>::mutate((holder.clone(), issuer.clone()), |topics| {
             if !topic_exists {
@@ -262,14 +264,8 @@ mod tests {
                 Attestation::topics((holder, issuer)),
                 [topic_food, topic_loot]
             );
-            assert_eq!(
-                Attestation::value((holder, issuer, topic_food)),
-                value_food
-            );
-            assert_eq!(
-                Attestation::value((holder, issuer, topic_loot)),
-                value_loot
-            );
+            assert_eq!(Attestation::value((holder, issuer, topic_food)), value_food);
+            assert_eq!(Attestation::value((holder, issuer, topic_loot)), value_loot);
         })
     }
 
@@ -329,10 +325,7 @@ mod tests {
 
             assert_eq!(Attestation::issuers(holder), []);
             assert_eq!(Attestation::topics((holder, issuer)), []);
-            assert_eq!(
-                Attestation::value((holder, issuer, topic)),
-                invalid_value
-            );
+            assert_eq!(Attestation::value((holder, issuer, topic)), invalid_value);
         })
     }
 
@@ -408,10 +401,7 @@ mod tests {
                 Attestation::value((holder, issuer, topic_food)),
                 invalid_value
             );
-            assert_eq!(
-                Attestation::value((holder, issuer, topic_loot)),
-                value_loot
-            );
+            assert_eq!(Attestation::value((holder, issuer, topic_loot)), value_loot);
         })
     }
 

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -68,12 +68,12 @@ decl_module! {
 
 			<Topics<T>>::mutate((holder.clone(), issuer.clone()),|topics| topics.retain(|vec_topic| *vec_topic != topic));
 
-			<Issuers<T>>::mutate(&holder, |issuers| (
-					issuers.retain(|vec_issuer| (
+			<Issuers<T>>::mutate(&holder, |issuers| {
+					issuers.retain(|vec_issuer| {
 						*vec_issuer != issuer.clone() ||
 						Self::get_topics((holder.clone(), issuer.clone())).len() != 0
-					))
-			));
+					})
+			});
 
 
 			Self::deposit_event(RawEvent::ClaimRemoved(holder, issuer, topic));

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -61,14 +61,6 @@ decl_module! {
 			Ok(())
 		}
 
-		/// Create a new claim where the holder and issuer are the same person
-		pub fn set_self_claim(origin, topic: AttestationTopic, value: AttestationValue) -> DispatchResult {
-			let holder_and_issuer = ensure_signed(origin)?;
-
-			Self::create_claim(holder_and_issuer.clone(), holder_and_issuer, topic, value)?;
-			Ok(())
-		}
-
 		/// Remove a claim, only the original issuer can remove a claim
 		pub fn remove_claim(origin, holder: T::AccountId, topic: AttestationTopic) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -253,5 +253,25 @@ mod tests {
 		})
 	}
 
+	#[test]
+	fn remove_claim_from_storage() {
+		let issuer = 0xf00;
+		let holder = 0xbaa;
+		let topic = AttestationTopic::from(0xf00d);
+		let value = AttestationValue::from(0xb33f);
+		ExtBuilder::build().execute_with(|| {
+			let result_add = Attestation::set_claim(Origin::signed(issuer), holder, topic, value);
+
+			let result_remove = Attestation::remove_claim(Origin::signed(issuer), holder, topic);
+
+			assert_eq!(result_add, Ok(()));
+			assert_eq!(result_remove, Ok(()));
+
+			assert_eq!(Attestation::get_issuers(holder), []);
+			assert_eq!(Attestation::get_topics((holder, issuer)), []);
+			assert_eq!(Attestation::get_value((holder, issuer, topic)), AttestationValue::from(0));
+		})
+	}
+
 
 }

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -228,12 +228,14 @@ mod tests {
         ExtBuilder::build().execute_with(|| {
             let result_old =
                 Attestation::set_claim(Origin::signed(issuer), holder, topic, value_old);
+
+            assert_ok!(result_old);
+            assert_eq!(Attestation::value((holder, issuer, topic)), value_old);
+
             let result_new =
                 Attestation::set_claim(Origin::signed(issuer), holder, topic, value_new);
 
-            assert_ok!(result_old);
             assert_ok!(result_new);
-
             assert_eq!(Attestation::value((holder, issuer, topic)), value_new);
         })
     }

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -145,7 +145,7 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{ExtBuilder, Attestation, Origin};
+	use crate::mock::{ExtBuilder, Attestation, Origin, TestEvent, System};
 
 	#[test]
 	fn initialize_holder_has_no_claims() {
@@ -355,5 +355,39 @@ mod tests {
 		})
 	}
 
+	#[test]
+	fn adding_claim_emits_event() {
+		let issuer = 0xf00;
+		let holder = 0xbaa;
+		let topic = AttestationTopic::from(0xf00d);
+		let value = AttestationValue::from(0xb33f);
+		ExtBuilder::build().execute_with(|| {
+			assert_eq!(Attestation::set_claim(Origin::signed(issuer), holder, topic, value), Ok(()));
+
+			let expected_event = TestEvent::attestation(
+				RawEvent::ClaimSet(holder, issuer, topic, value),
+			);
+			// Assert
+			assert!(System::events().iter().any(|record| record.event == expected_event));
+		})
+	}
+
+	#[test]
+	fn removing_claim_emits_event() {
+		let issuer = 0xf00;
+		let holder = 0xbaa;
+		let topic = AttestationTopic::from(0xf00d);
+		let value = AttestationValue::from(0xb33f);
+		ExtBuilder::build().execute_with(|| {
+			assert_eq!(Attestation::set_claim(Origin::signed(issuer), holder, topic, value), Ok(()));
+			assert_eq!(Attestation::remove_claim(Origin::signed(issuer), holder, topic), Ok(()));
+
+			let expected_event = TestEvent::attestation(
+				RawEvent::ClaimRemoved(holder, issuer, topic),
+			);
+			// Assert
+			assert!(System::events().iter().any(|record| record.event == expected_event));
+		})
+	}
 
 }

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -91,7 +91,7 @@ decl_module! {
 
 decl_event!(
 	pub enum Event<T> where <T as frame_system::Trait>::AccountId {
-		ClaimSet(AccountId, AccountId, AttestationTopic, AttestationValue),
+		ClaimCreated(AccountId, AccountId, AttestationTopic, AttestationValue),
 		ClaimRemoved(AccountId, AccountId, AttestationTopic),
 		ClaimUpdated(AccountId, AccountId, AttestationTopic, AttestationValue),
 	}
@@ -159,7 +159,7 @@ impl<T: Trait> Module<T> {
 			Self::deposit_event(RawEvent::ClaimUpdated(holder, issuer, topic, value));
 		}
 		else {
-			Self::deposit_event(RawEvent::ClaimSet(holder, issuer, topic, value));
+			Self::deposit_event(RawEvent::ClaimCreated(holder, issuer, topic, value));
 		}
 	}
 }
@@ -394,7 +394,7 @@ mod tests {
 	}
 
 	#[test]
-	fn adding_claim_emits_event() {
+	fn created_claim_emits_event() {
 		let issuer = 0xf00;
 		let holder = 0xbaa;
 		let topic = AttestationTopic::from(0xf00d);
@@ -403,7 +403,7 @@ mod tests {
 			assert_ok!(Attestation::set_claim(Origin::signed(issuer), holder, topic, value));
 
 			let expected_event = TestEvent::attestation(
-				RawEvent::ClaimSet(holder, issuer, topic, value),
+				RawEvent::ClaimCreated(holder, issuer, topic, value),
 			);
 			// Assert
 			assert!(System::events().iter().any(|record| record.event == expected_event));

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -72,9 +72,17 @@ decl_module! {
 		/// Remove a claim, only the original issuer can remove a claim
 		pub fn remove_claim(origin, holder: T::AccountId, topic: AttestationTopic) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
-			<Issuers<T>>::mutate(&holder,|issuers| issuers.retain(|vec_issuer| *vec_issuer != issuer));
-			<Topics<T>>::mutate((holder.clone(), issuer.clone()),|topics| topics.retain(|vec_topic| *vec_topic != topic));
 			<Values<T>>::remove((holder.clone(), issuer.clone(), topic));
+
+			<Topics<T>>::mutate((holder.clone(), issuer.clone()),|topics| topics.retain(|vec_topic| *vec_topic != topic));
+
+			<Issuers<T>>::mutate(&holder, |issuers| (
+					issuers.retain(|vec_issuer| (
+						*vec_issuer != issuer.clone() ||
+						Self::get_topics((holder.clone(), issuer.clone())).len() != 0
+					))
+			));
+
 
 			Self::deposit_event(RawEvent::ClaimRemoved(holder, issuer, topic));
 
@@ -259,6 +267,7 @@ mod tests {
 		let holder = 0xbaa;
 		let topic = AttestationTopic::from(0xf00d);
 		let value = AttestationValue::from(0xb33f);
+		let invalid_value = AttestationValue::zero();
 		ExtBuilder::build().execute_with(|| {
 			let result_add = Attestation::set_claim(Origin::signed(issuer), holder, topic, value);
 
@@ -269,7 +278,88 @@ mod tests {
 
 			assert_eq!(Attestation::get_issuers(holder), []);
 			assert_eq!(Attestation::get_topics((holder, issuer)), []);
-			assert_eq!(Attestation::get_value((holder, issuer, topic)), AttestationValue::from(0));
+			assert_eq!(Attestation::get_value((holder, issuer, topic)), invalid_value);
+		})
+	}
+
+	#[test]
+	fn remove_claim_from_account_with_multiple_issuers() {
+		let issuer_foo = 0xf00;
+		let issuer_boa = 0xb0a;
+		let holder = 0xbaa;
+		let topic_food = AttestationTopic::from(0xf00d);
+		let value_food_foo = AttestationValue::from(0xb33f);
+		let value_food_boa = AttestationValue::from(0x90a7);
+		let invalid_value = AttestationValue::zero();
+		ExtBuilder::build().execute_with(|| {
+			let result_foo = Attestation::set_claim(Origin::signed(issuer_foo), holder, topic_food, value_food_foo);
+			let result_boa = Attestation::set_claim(Origin::signed(issuer_boa), holder, topic_food, value_food_boa);
+
+			let result_remove = Attestation::remove_claim(Origin::signed(issuer_foo), holder, topic_food);
+
+			assert_eq!(result_foo, Ok(()));
+			assert_eq!(result_boa, Ok(()));
+			assert_eq!(result_remove, Ok(()));
+
+			assert_eq!(Attestation::get_issuers(holder), [issuer_boa]);
+			assert_eq!(Attestation::get_topics((holder, issuer_foo)), []);
+			assert_eq!(Attestation::get_topics((holder, issuer_boa)), [topic_food]);
+			assert_eq!(Attestation::get_value((holder, issuer_foo, topic_food)), invalid_value);
+			assert_eq!(Attestation::get_value((holder, issuer_boa, topic_food)), value_food_boa);
+		})
+	}
+
+	#[test]
+	fn remove_claim_from_account_with_multiple_claims_from_same_issuer() {
+		let issuer = 0xf00;
+		let holder = 0xbaa;
+		let topic_food = AttestationTopic::from(0xf00d);
+		let value_food = AttestationValue::from(0xb33f);
+		let topic_loot = AttestationTopic::from(0x1007);
+		let value_loot = AttestationValue::from(0x901d);
+		let invalid_value = AttestationValue::zero();
+		ExtBuilder::build().execute_with(|| {
+			let result_food = Attestation::set_claim(Origin::signed(issuer), holder, topic_food, value_food);
+			let result_loot = Attestation::set_claim(Origin::signed(issuer), holder, topic_loot, value_loot);
+
+			let result_remove = Attestation::remove_claim(Origin::signed(issuer), holder, topic_food);
+
+			assert_eq!(result_food, Ok(()));
+			assert_eq!(result_loot, Ok(()));
+			assert_eq!(result_remove, Ok(()));
+
+			assert_eq!(Attestation::get_issuers(holder), [issuer]);
+			assert_eq!(Attestation::get_topics((holder, issuer)), [topic_loot]);
+			assert_eq!(Attestation::get_value((holder, issuer, topic_food)), invalid_value);
+			assert_eq!(Attestation::get_value((holder, issuer, topic_loot)), value_loot);
+		})
+	}
+
+	#[test]
+	fn issuer_is_removed_if_there_are_no_claims_left() {
+		let issuer = 0xf00;
+		let holder = 0xbaa;
+		let topic_food = AttestationTopic::from(0xf00d);
+		let value_food = AttestationValue::from(0xb33f);
+		let topic_loot = AttestationTopic::from(0x1007);
+		let value_loot = AttestationValue::from(0x901d);
+		let invalid_value = AttestationValue::zero();
+		ExtBuilder::build().execute_with(|| {
+			let result_food = Attestation::set_claim(Origin::signed(issuer), holder, topic_food, value_food);
+			let result_loot = Attestation::set_claim(Origin::signed(issuer), holder, topic_loot, value_loot);
+
+			let result_remove_food = Attestation::remove_claim(Origin::signed(issuer), holder, topic_food);
+			let result_remove_loot = Attestation::remove_claim(Origin::signed(issuer), holder, topic_loot);
+
+			assert_eq!(result_food, Ok(()));
+			assert_eq!(result_loot, Ok(()));
+			assert_eq!(result_remove_food, Ok(()));
+			assert_eq!(result_remove_loot, Ok(()));
+
+			assert_eq!(Attestation::get_issuers(holder), []);
+			assert_eq!(Attestation::get_topics((holder, issuer)), []);
+			assert_eq!(Attestation::get_value((holder, issuer, topic_food)), invalid_value);
+			assert_eq!(Attestation::get_value((holder, issuer, topic_loot)), invalid_value);
 		})
 	}
 

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -57,7 +57,7 @@ decl_module! {
 		pub fn set_claim(origin, holder: T::AccountId, topic: AttestationTopic, value: AttestationValue) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 
-			Self::create_claim(holder, issuer, topic, value)?;
+			Self::create_or_update_claim(holder, issuer, topic, value)?;
 			Ok(())
 		}
 
@@ -130,7 +130,10 @@ decl_error! {
 }
 
 impl<T: Trait> Module<T> {
-	fn create_claim(
+	/// Sets a claim about a `holder` from an `issuer`
+	/// If the claim `topic` already exists, then the claim `value` is updated,
+	/// Otherwise, a new claim is created for the `holder` by the `issuer`
+	fn create_or_update_claim(
 		holder: T::AccountId,
 		issuer: T::AccountId,
 		topic: AttestationTopic,

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -39,7 +39,7 @@ mod mock;
 
 use sp_core::uint::U256;
 use frame_support::sp_std::prelude::*;
-use frame_support::{ensure, decl_event, decl_module, decl_storage, decl_error, dispatch::DispatchResult};
+use frame_support::{ensure, decl_event, decl_module, decl_storage, decl_error, dispatch::DispatchResult, weights::SimpleDispatchInfo,};
 use frame_system::ensure_signed;
 
 pub trait Trait: frame_system::Trait {
@@ -56,6 +56,7 @@ decl_module! {
 		/// Create or update an existing claim
 		/// The `issuer` of the claim comes from the extrinsic `origin`
 		/// The `topic` and `value` are both U256 which can hold any 32-byte encoded data.
+		#[weight = SimpleDispatchInfo::FixedNormal(100_000)]
 		pub fn set_claim(origin, holder: T::AccountId, topic: AttestationTopic, value: AttestationValue) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 
@@ -65,6 +66,7 @@ decl_module! {
 
 		/// Remove a claim, only the original issuer can remove a claim
 		/// If the `issuer` has not yet issued a claim of `topic`, this function will return error.
+		#[weight = SimpleDispatchInfo::FixedNormal(100_000)]
 		pub fn remove_claim(origin, holder: T::AccountId, topic: AttestationTopic) -> DispatchResult {
 			let issuer = ensure_signed(origin)?;
 

--- a/prml/attestation/src/lib.rs
+++ b/prml/attestation/src/lib.rs
@@ -82,13 +82,12 @@ decl_module! {
 
             <Topics<T>>::mutate((holder.clone(), issuer.clone()),|topics| topics.retain(|vec_topic| *vec_topic != topic));
 
-            <Issuers<T>>::mutate(&holder, |issuers| {
-                    issuers.retain(|vec_issuer| {
-                        *vec_issuer != issuer.clone() ||
-                        <Topics<T>>::get((holder.clone(), issuer.clone())).len() != 0
-                    })
-            });
-
+            let remove_issuer = <Topics<T>>::get((holder.clone(), issuer.clone())).len() == 0;
+            if remove_issuer {
+                <Issuers<T>>::mutate(&holder, |issuers| {
+                    issuers.retain(|vec_issuer| *vec_issuer != issuer.clone())
+                });
+            }
 
             Self::deposit_event(RawEvent::ClaimRemoved(holder, issuer, topic));
 

--- a/prml/attestation/src/mock.rs
+++ b/prml/attestation/src/mock.rs
@@ -1,0 +1,115 @@
+// Copyright 2019-2020
+//     by  Centrality Investments Ltd.
+//     and Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Mocks for the module.
+
+#![cfg(test)]
+
+use sp_runtime::{
+	Perbill,
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+use sp_core::H256;
+use frame_support::{parameter_types, impl_outer_event, impl_outer_origin, weights::Weight};
+
+use super::*;
+
+impl_outer_origin! {
+	pub enum Origin for Test  where system = frame_system {}
+}
+
+// For testing the pallet, we construct most of a mock runtime. This means
+// first constructing a configuration type (`Test`) which `impl`s each of the
+// configuration traits of pallets we want to use.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Test;
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl frame_system::Trait for Test {
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Call = ();
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<u64>;
+	type Header = Header;
+	type Event = TestEvent;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type ModuleToIndex = ();
+	type Doughnut = ();
+	type DelegatedDispatchVerifier = ();
+}
+
+impl Trait for Test {
+	type Event = TestEvent;
+}
+
+mod attestation {
+	pub use crate::Event;
+}
+
+use frame_system as system;
+impl_outer_event! {
+	pub enum TestEvent for Test {
+		attestation<T>,
+	}
+}
+
+pub type Attestation = Module<Test>;
+
+pub type System = frame_system::Module<Test>;
+
+pub struct ExtBuilder {
+}
+
+// Returns default values for genesis config
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self {
+		}
+	}
+}
+
+impl ExtBuilder {
+
+	// builds genesis config
+	pub fn build() -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		t.into()
+	}
+}
+
+// This function basically just builds a genesis storage key/value store according to
+// our desired mockup.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
+}

--- a/prml/attestation/src/mock.rs
+++ b/prml/attestation/src/mock.rs
@@ -83,6 +83,8 @@ impl_outer_event! {
 
 pub type Attestation = Module<Test>;
 
+pub type System = frame_system::Module<Test>;
+
 pub struct ExtBuilder {
 }
 

--- a/prml/attestation/src/mock.rs
+++ b/prml/attestation/src/mock.rs
@@ -83,8 +83,6 @@ impl_outer_event! {
 
 pub type Attestation = Module<Test>;
 
-pub type System = frame_system::Module<Test>;
-
 pub struct ExtBuilder {
 }
 

--- a/prml/attestation/src/mock.rs
+++ b/prml/attestation/src/mock.rs
@@ -20,18 +20,18 @@
 
 #![cfg(test)]
 
-use sp_runtime::{
-	Perbill,
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use sp_core::H256;
-use frame_support::{parameter_types, impl_outer_event, impl_outer_origin, weights::Weight};
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
 
 use super::*;
 
 impl_outer_origin! {
-	pub enum Origin for Test  where system = frame_system {}
+    pub enum Origin for Test  where system = frame_system {}
 }
 
 // For testing the pallet, we construct most of a mock runtime. This means
@@ -40,66 +40,66 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Test;
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Call = ();
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<u64>;
-	type Header = Header;
-	type Event = TestEvent;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type MaximumBlockLength = MaximumBlockLength;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type ModuleToIndex = ();
-	type Doughnut = ();
-	type DelegatedDispatchVerifier = ();
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Call = ();
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<u64>;
+    type Header = Header;
+    type Event = TestEvent;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type ModuleToIndex = ();
+    type Doughnut = ();
+    type DelegatedDispatchVerifier = ();
 }
 
 impl Trait for Test {
-	type Event = TestEvent;
+    type Event = TestEvent;
 }
 
 mod attestation {
-	pub use crate::Event;
+    pub use crate::Event;
 }
 
 use frame_system as system;
 impl_outer_event! {
-	pub enum TestEvent for Test {
-		attestation<T>,
-	}
+    pub enum TestEvent for Test {
+        attestation<T>,
+    }
 }
 
 pub type Attestation = Module<Test>;
 
 pub type System = frame_system::Module<Test>;
 
-pub struct ExtBuilder {
-}
+pub struct ExtBuilder {}
 
 // Returns default values for genesis config
 impl Default for ExtBuilder {
-	fn default() -> Self {
-		Self {
-		}
-	}
+    fn default() -> Self {
+        Self {}
+    }
 }
 
 impl ExtBuilder {
-
-	// builds genesis config
-	pub fn build() -> sp_io::TestExternalities {
-		frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
-	}
+    // builds genesis config
+    pub fn build() -> sp_io::TestExternalities {
+        frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap()
+            .into()
+    }
 }

--- a/prml/attestation/src/mock.rs
+++ b/prml/attestation/src/mock.rs
@@ -100,16 +100,6 @@ impl ExtBuilder {
 
 	// builds genesis config
 	pub fn build() -> sp_io::TestExternalities {
-		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		t.into()
+		frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
 	}
-}
-
-// This function basically just builds a genesis storage key/value store according to
-// our desired mockup.
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::default()
-		.build_storage::<Test>()
-		.unwrap()
-		.into()
 }


### PR DESCRIPTION
The following changes were made:

- Add fixed fee weights to `set_claim` and `remove_claim`
- Remove `set_self_claim` - there is a unit test which shows that a user can perform a self-claim using `set_claim` instead
- `ClaimSet` event has been replaced with `ClaimCreated` and `ClaimUpdated` to distinguish between the possible outcomes of `set_claim`
- `remove_claim` bug which removes an issuer who may have multiple claims on a holder has been resolved
- Will return `Error::TopicNotRegistered` when attempting to delete a non-existent topic
- Add doc comments
- Add 14 regression tests 

Concerns: 
- No regression tests added to cover fixed fee weights