### PR TITLE
Chore/162 improve imbalance

### DIFF
--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -911,15 +911,16 @@ mod imbalances {
 	};
 	use sp_std::mem;
 
-	/// Base trait used to avoid duplicaate code that is implemented for both the Positive and Negative
-	/// imlances.
+	/// Trait used to avoid duplicate code that is implemented for both the Positive and Negative
+	/// imbalances.
+	/// Provide access to asset ID within imbalance structs
 	pub trait ImbalanceWithAssetId<T: Subtrait>{
 		fn asset_id(&self) -> T::AssetId;
 		fn set_asset_id(&mut self, asset_id : T::AssetId);
 
 		/// This is a helper function that checks the consistency of asset ID for operations on Imbalances
 		///
-		/// If the imblance a has no asset_id configured ( asset_id == 0 ), a takes on b's asset_id
+		/// If the imbalance a has no asset_id configured ( asset_id == 0 ), a takes on b's asset_id
 		///
 		/// If a and b do not have matching asset_ids, debug_assert and return false.
 		/// Otherwise return true

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -938,9 +938,6 @@ mod imbalances {
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			PositiveImbalance(amount, asset_id)
 		}
-		pub fn balance(&self) -> T::Balance {
-			self.0
-		}
 		pub fn asset_id(&self) -> T::AssetId {
 			self.1
 		}
@@ -973,9 +970,6 @@ mod imbalances {
 
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			NegativeImbalance(amount, asset_id)
-		}
-		pub fn balance(&self) -> T::Balance {
-			self.0
 		}
 		pub fn asset_id(&self) -> T::AssetId {
 			self.1

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -938,6 +938,12 @@ mod imbalances {
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			PositiveImbalance(amount, asset_id)
 		}
+		pub fn balance(&self) -> T::Balance {
+			self.0
+		}
+		pub fn asset_id(&self) -> T::AssetId {
+			self.1
+		}
 	}
 
 	/// Opaque, move-only struct with private fields that serves as a token denoting that
@@ -967,6 +973,12 @@ mod imbalances {
 
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			NegativeImbalance(amount, asset_id)
+		}
+		pub fn balance(&self) -> T::Balance {
+			self.0
+		}
+		pub fn asset_id(&self) -> T::AssetId {
+			self.1
 		}
 	}
 

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -913,7 +913,7 @@ mod imbalances {
 
 	/// Provide access to asset ID within imbalance structs
 	pub trait ImbalanceWithAssetId<T: Subtrait>{
-		fn asset_id(&self) -> T::AssetId;
+		fn get_asset_id(&self) -> T::AssetId;
 		fn set_asset_id(&mut self, asset_id : T::AssetId);
 
 		/// This is a helper function that checks the consistency of asset ID for operations on Imbalances
@@ -924,11 +924,11 @@ mod imbalances {
 		/// Otherwise return true
 		fn match_asset_id(&mut self, other: &Self) -> bool {
 			let mut result = true;
-			if self.asset_id() == Zero::zero() {
-				self.set_asset_id(other.asset_id().clone());
+			if self.get_asset_id() == Zero::zero() {
+				self.set_asset_id(other.get_asset_id().clone());
 			}
 
-			if self.asset_id() != other.asset_id() {
+			if self.get_asset_id() != other.get_asset_id() {
 				debug_assert!(false, "Asset ID do not match!");
 				result = false;
 			}
@@ -946,12 +946,9 @@ mod imbalances {
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			PositiveImbalance(amount, asset_id)
 		}
-		pub fn asset_id(&self) -> T::AssetId {
-			self.1
-		}
 	}
 	impl<T: Subtrait> ImbalanceWithAssetId<T> for PositiveImbalance<T>{
-		fn asset_id(&self) -> T::AssetId {
+		fn get_asset_id(&self) -> T::AssetId {
 			self.1
 		}
 		fn set_asset_id(&mut self, asset_id : T::AssetId){
@@ -968,13 +965,10 @@ mod imbalances {
 		pub fn new(amount: T::Balance, asset_id: T::AssetId) -> Self {
 			NegativeImbalance(amount, asset_id)
 		}
-		pub fn asset_id(&self) -> T::AssetId {
-			self.1
-		}
 	}
 
 	impl<T: Subtrait> ImbalanceWithAssetId<T> for NegativeImbalance<T> {
-		fn asset_id(&self) -> T::AssetId {
+		fn get_asset_id(&self) -> T::AssetId {
 			self.1
 		}
 		fn set_asset_id(&mut self, asset_id: T::AssetId) {

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -911,8 +911,6 @@ mod imbalances {
 	};
 	use sp_std::mem;
 
-	/// Trait used to avoid duplicate code that is implemented for both the Positive and Negative
-	/// imbalances.
 	/// Provide access to asset ID within imbalance structs
 	pub trait ImbalanceWithAssetId<T: Subtrait>{
 		fn asset_id(&self) -> T::AssetId;

--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -20,6 +20,7 @@
 
 #![cfg(test)]
 
+use crate::{NegativeImbalance, PositiveImbalance};
 use sp_runtime::{
 	Perbill,
 	testing::Header,
@@ -33,6 +34,9 @@ use super::*;
 impl_outer_origin! {
 	pub enum Origin for Test  where system = frame_system {}
 }
+
+pub type PositiveImbalanceOf = PositiveImbalance<Test>;
+pub type NegativeImbalanceOf = NegativeImbalance<Test>;
 
 // For testing the pallet, we construct most of a mock runtime. This means
 // first constructing a configuration type (`Test`) which `impl`s each of the

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -22,7 +22,7 @@
 
 use super::*;
 use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, System, Test, TestEvent, PositiveImbalanceOf, NegativeImbalanceOf};
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::Imbalance};
 
 #[test]
 fn issuing_asset_units_to_issuer_should_work() {
@@ -1296,64 +1296,141 @@ fn zero_asset_id_should_updated_after_imbalance_operations() {
 }
 
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
+	let asset_id = 16000;
+	let balance = 100000;
+	ExtBuilder::default()
+		.free_balance((asset_id, 1, balance))
+		.build()
+		.execute_with(|| {
+			// generate empty positive imbalance
+			let positive_im = PositiveImbalanceOf::zero();
+			let other = PositiveImbalanceOf::new(100, asset_id);
+			assert_eq!(positive_im.asset_id(), 0);
+			assert_eq!(positive_im.balance(), 0);
+			// merge
+			let merged_im = positive_im.merge(other);
+			assert_eq!(merged_im.asset_id(), asset_id);
+			assert_eq!(merged_im.balance(), 100);
+			// subsume
+			let mut positive_im = PositiveImbalanceOf::zero();
+			let other = PositiveImbalanceOf::new(100, asset_id);
+			positive_im.subsume(other);
+			assert_eq!(positive_im.asset_id(), asset_id);
+			assert_eq!(positive_im.balance(), 100);
+			// offset
+			let negative_im = PositiveImbalanceOf::new(100, 0);
+			let opposite_im = NegativeImbalanceOf::new(50, asset_id);
+			let offset_im = negative_im.offset(opposite_im).unwrap();
+			assert_eq!(offset_im.asset_id(), asset_id);
+			assert_eq!(offset_im.balance(), 50);
+	});
+}
+
+#[test]
+#[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_merge_with_imcompatible_asset_id_should_panic() {
-	// create new positive imbalance
-	let negative_im = NegativeImbalanceOf::new(100, 1);
-	let other = NegativeImbalanceOf::new(50, 2);
-	// merge
-	let _ = negative_im.merge(other);
+	ExtBuilder::default().build().execute_with(|| {
+		// create new positive imbalance
+		let negative_im = NegativeImbalanceOf::new(100, 1);
+		let other = NegativeImbalanceOf::new(50, 2);
+		// merge
+		let _ = negative_im.merge(other);
+	});
 }
 
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+#[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_merge_with_imcompatible_asset_id_should_panic() {
-	// create new positive imbalance
-	let positive_im = PositiveImbalanceOf::new(100, 1);
-	let other = PositiveImbalanceOf::new(50, 2);
-	// merge
-	let _ = positive_im.merge(other);
+	ExtBuilder::default().build().execute_with(|| {
+		// create new positive imbalance
+		let positive_im = PositiveImbalanceOf::new(100, 1);
+		let other = PositiveImbalanceOf::new(50, 2);
+		// merge
+		let _ = positive_im.merge(other);
+	});
 }
 
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+#[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_subsume_with_imcompatible_asset_id_should_panic() {
-	// create new positive imbalance
-	let mut negative_im = NegativeImbalanceOf::new(100, 1);
-	let other = NegativeImbalanceOf::new(50, 2);
-	// merge
-	negative_im.subsume(other);
+	ExtBuilder::default().build().execute_with(|| {
+		// create new positive imbalance
+		let mut negative_im = NegativeImbalanceOf::new(100, 1);
+		let other = NegativeImbalanceOf::new(50, 2);
+		// merge
+		negative_im.subsume(other);
+	});
 }
 
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+#[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_subsume_with_imcompatible_asset_id_should_panic() {
-	// create new positive imbalance
-	let mut positive_im = PositiveImbalanceOf::new(100, 1);
-	let other = PositiveImbalanceOf::new(50, 2);
-	// merge
-	positive_im.subsume(other);
+	ExtBuilder::default().build().execute_with(|| {
+		// create new positive imbalance
+		let mut positive_im = PositiveImbalanceOf::new(100, 1);
+		let other = PositiveImbalanceOf::new(50, 2);
+		// merge
+		positive_im.subsume(other);
+	});
 }
 
-
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+#[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_offset_with_imcompatible_asset_id_should_panic() {
-	let negative_im = NegativeImbalanceOf::new(100, 1);
-	let opposite_im = PositiveImbalanceOf::new(50, 2);
-	let _ = negative_im.offset(opposite_im);
+	ExtBuilder::default().build().execute_with(|| {
+		let negative_im = NegativeImbalanceOf::new(100, 1);
+		let opposite_im = PositiveImbalanceOf::new(50, 2);
+		let _ = negative_im.offset(opposite_im);
+	});
 }
 
 #[test]
-#[ignore]
-#[should_panic(expected = "asset id imcompatible")]
+#[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_offset_with_imcompatible_asset_id_should_panic() {
-	let positive_im = PositiveImbalanceOf::new(100, 1);
-	let opposite_im = NegativeImbalanceOf::new(50, 2);
-	let _ = positive_im.offset(opposite_im);
+	ExtBuilder::default().build().execute_with(|| {
+		let positive_im = PositiveImbalanceOf::new(100, 1);
+		let opposite_im = NegativeImbalanceOf::new(50, 2);
+		let _ = positive_im.offset(opposite_im);
+	});
+}
+
+#[test]
+fn total_issuance_should_update_after_positive_imbalance_dropped() {
+	let asset_id = 16000;
+	let balance = 100000;
+	ExtBuilder::default()
+		.free_balance((asset_id, 1, balance))
+		.build()
+		.execute_with(|| {
+			assert_eq!(GenericAsset::total_issuance(&asset_id), balance);
+			// generate empty positive imbalance
+			let positive_im = PositiveImbalanceOf::zero();
+			let other = PositiveImbalanceOf::new(100, asset_id);
+			// merge
+			let merged_im = positive_im.merge(other);
+			// explitically drop `imbalance` so issuance is managed
+			drop(merged_im);
+			assert_eq!(GenericAsset::total_issuance(&asset_id), balance + 100);
+	});
+}
+
+#[test]
+fn total_issuance_should_update_after_negative_imbalance_dropped() {
+	let asset_id = 16000;
+	let balance = 100000;
+	ExtBuilder::default()
+		.free_balance((asset_id, 1, balance))
+		.build()
+		.execute_with(|| {
+			assert_eq!(GenericAsset::total_issuance(&asset_id), balance);
+			// generate empty positive imbalance
+			let positive_im = NegativeImbalanceOf::zero();
+			let other = NegativeImbalanceOf::new(100, asset_id);
+			// merge
+			let merged_im = positive_im.merge(other);
+			// explitically drop `imbalance` so issuance is managed
+			drop(merged_im);
+			assert_eq!(GenericAsset::total_issuance(&asset_id), balance - 100);
+	});
 }

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -1338,6 +1338,7 @@ fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1350,6 +1351,7 @@ fn negative_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1362,6 +1364,7 @@ fn positive_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1374,6 +1377,7 @@ fn negative_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1386,6 +1390,7 @@ fn positive_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn negative_imbalance_offset_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1396,6 +1401,7 @@ fn negative_imbalance_offset_with_imcompatible_asset_id_should_fail() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
 fn positive_imbalance_offset_with_imcompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -1253,28 +1253,43 @@ fn zero_asset_id_should_updated_after_negative_imbalance_operations() {
 	ExtBuilder::default()
 		.build()
 		.execute_with(|| {
+			// generate empty negative imbalance
 			let negative_im = NegativeImbalanceOf::zero();
 			let other = NegativeImbalanceOf::new(100, asset_id);
 			assert_eq!(negative_im.asset_id(), 0);
 			assert_eq!(negative_im.peek(), 0);
 			assert_eq!(other.asset_id(), asset_id);
-			// merge
+			// zero asset id should updated after merge
 			let merged_im = negative_im.merge(other);
 			assert_eq!(merged_im.asset_id(), asset_id);
 			assert_eq!(merged_im.peek(), 100);
-			// subsume
+			// merge other with same asset id should work
+			let other = NegativeImbalanceOf::new(100, asset_id);
+			let merged_im = merged_im.merge(other);
+			assert_eq!(merged_im.peek(), 200);
+
+			// zero asset id should updated after subsume
 			let mut negative_im = NegativeImbalanceOf::zero();
 			let other = NegativeImbalanceOf::new(100, asset_id);
 			assert_eq!(negative_im.asset_id(), 0);
 			negative_im.subsume(other);
 			assert_eq!(negative_im.asset_id(), asset_id);
 			assert_eq!(negative_im.peek(), 100);
-			// offset
+			// subsume other with same asset id should work
+			let other = NegativeImbalanceOf::new(100, asset_id);
+			negative_im.subsume(other);
+			assert_eq!(negative_im.peek(), 200);
+
+			// zero asset id should updated after offset with opposite im
 			let negative_im = NegativeImbalanceOf::new(100, 0);
 			let opposite_im = PositiveImbalanceOf::new(50, asset_id);
 			let offset_im = negative_im.offset(opposite_im).unwrap();
 			assert_eq!(offset_im.asset_id(), asset_id);
 			assert_eq!(offset_im.peek(), 50);
+			// offset opposite im with same asset id should work
+			let opposite_im = PositiveImbalanceOf::new(25, asset_id);
+			let offset_im = offset_im.offset(opposite_im).unwrap();
+			assert_eq!(offset_im.peek(), 25);
 		});
 }
 
@@ -1289,22 +1304,36 @@ fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
 			let other = PositiveImbalanceOf::new(100, asset_id);
 			assert_eq!(positive_im.asset_id(), 0);
 			assert_eq!(positive_im.peek(), 0);
-			// merge
+			// zero asset id should updated after merge
 			let merged_im = positive_im.merge(other);
 			assert_eq!(merged_im.asset_id(), asset_id);
 			assert_eq!(merged_im.peek(), 100);
+			// merge other with same asset id should work
+			let other = PositiveImbalanceOf::new(100, asset_id);
+			let merged_im = merged_im.merge(other);
+			assert_eq!(merged_im.peek(), 200);
+			
 			// subsume
 			let mut positive_im = PositiveImbalanceOf::zero();
 			let other = PositiveImbalanceOf::new(100, asset_id);
 			positive_im.subsume(other);
 			assert_eq!(positive_im.asset_id(), asset_id);
 			assert_eq!(positive_im.peek(), 100);
-			// offset
+			// subsume other with same asset id should work
+			let other = PositiveImbalanceOf::new(100, asset_id);
+			negative_im.subsume(other);
+			assert_eq!(negative_im.peek(), 200);
+			
+			// zero asset id should updated after offset with opposite im
 			let negative_im = PositiveImbalanceOf::new(100, 0);
 			let opposite_im = NegativeImbalanceOf::new(50, asset_id);
 			let offset_im = negative_im.offset(opposite_im).unwrap();
 			assert_eq!(offset_im.asset_id(), asset_id);
 			assert_eq!(offset_im.peek(), 50);
+			// offset opposite im with same asset id should work
+			let opposite_im = NegativeImbalanceOf::new(25, asset_id);
+			let offset_im = offset_im.offset(opposite_im).unwrap();
+			assert_eq!(offset_im.peek(), 25);
 	});
 }
 

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -23,6 +23,7 @@
 use super::*;
 use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, System, Test, TestEvent, PositiveImbalanceOf, NegativeImbalanceOf};
 use frame_support::{assert_noop, assert_ok, traits::Imbalance};
+use crate::imbalances::ImbalanceWithAssetId;
 
 #[test]
 fn issuing_asset_units_to_issuer_should_work() {

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -1246,84 +1246,64 @@ fn can_set_asset_owner_permissions_in_genesis() {
 	});
 }
 
-#[ignore]
-fn zero_asset_id_should_updated_after_imbalance_operations() {
-	let asset_id = 2;
-	let negative_im = NegativeImbalanceOf::zero();
-	let other = NegativeImbalanceOf::new(100, asset_id);
-	assert_eq!(negative_im.asset_id(), 0);
-	assert_eq!(negative_im.balance(), 0);
-	assert_eq!(other.asset_id(), 1);
-	// merge
-	let merged_im = negative_im.merge(other);
-	assert_eq!(merged_im.asset_id(), asset_id);
-	assert_eq!(merged_im.balance(), 100);
-	// subsume
-	let mut negative_im = NegativeImbalanceOf::zero();
-	let other = NegativeImbalanceOf::new(100, asset_id);
-	assert_eq!(negative_im.asset_id(), 0);
-	negative_im.subsume(other);
-	assert_eq!(negative_im.asset_id(), asset_id);
-	assert_eq!(negative_im.balance(), 100);
-	// offset
-	let negative_im = NegativeImbalanceOf::new(100, 0);
-	let opposite_im = PositiveImbalanceOf::new(50, asset_id);
-	let offset_im = negative_im.offset(opposite_im).unwrap();
-	assert_eq!(offset_im.asset_id(), asset_id);
-	assert_eq!(offset_im.balance(), 50);
-
-	// generate empty positive imbalance
-	let positive_im = PositiveImbalanceOf::zero();
-	let other = PositiveImbalanceOf::new(100, asset_id);
-	assert_eq!(positive_im.asset_id(), 0);
-	assert_eq!(positive_im.balance(), 0);
-	// merge
-	let merged_im = positive_im.merge(other);
-	assert_eq!(merged_im.asset_id(), asset_id);
-	assert_eq!(merged_im.balance(), 100);
-	// subsume
-	let mut positive_im = PositiveImbalanceOf::zero();
-	let other = PositiveImbalanceOf::new(100, asset_id);
-	positive_im.subsume(other);
-	assert_eq!(positive_im.asset_id(), asset_id);
-	assert_eq!(positive_im.balance(), 100);
-	// offset
-	let negative_im = PositiveImbalanceOf::new(100, 0);
-	let opposite_im = NegativeImbalanceOf::new(50, asset_id);
-	let offset_im = negative_im.offset(opposite_im).unwrap();
-	assert_eq!(offset_im.asset_id(), asset_id);
-	assert_eq!(offset_im.balance(), 50);
+#[test]
+fn zero_asset_id_should_updated_after_negative_imbalance_operations() {
+	let asset_id = 16000;
+	ExtBuilder::default()
+		.build()
+		.execute_with(|| {
+			let negative_im = NegativeImbalanceOf::zero();
+			let other = NegativeImbalanceOf::new(100, asset_id);
+			assert_eq!(negative_im.asset_id(), 0);
+			assert_eq!(negative_im.peek(), 0);
+			assert_eq!(other.asset_id(), asset_id);
+			// merge
+			let merged_im = negative_im.merge(other);
+			assert_eq!(merged_im.asset_id(), asset_id);
+			assert_eq!(merged_im.peek(), 100);
+			// subsume
+			let mut negative_im = NegativeImbalanceOf::zero();
+			let other = NegativeImbalanceOf::new(100, asset_id);
+			assert_eq!(negative_im.asset_id(), 0);
+			negative_im.subsume(other);
+			assert_eq!(negative_im.asset_id(), asset_id);
+			assert_eq!(negative_im.peek(), 100);
+			// offset
+			let negative_im = NegativeImbalanceOf::new(100, 0);
+			let opposite_im = PositiveImbalanceOf::new(50, asset_id);
+			let offset_im = negative_im.offset(opposite_im).unwrap();
+			assert_eq!(offset_im.asset_id(), asset_id);
+			assert_eq!(offset_im.peek(), 50);
+		});
 }
 
 #[test]
 fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
 	let asset_id = 16000;
-	let balance = 100000;
 	ExtBuilder::default()
-		.free_balance((asset_id, 1, balance))
 		.build()
 		.execute_with(|| {
 			// generate empty positive imbalance
 			let positive_im = PositiveImbalanceOf::zero();
 			let other = PositiveImbalanceOf::new(100, asset_id);
 			assert_eq!(positive_im.asset_id(), 0);
-			assert_eq!(positive_im.balance(), 0);
+			assert_eq!(positive_im.peek(), 0);
 			// merge
 			let merged_im = positive_im.merge(other);
 			assert_eq!(merged_im.asset_id(), asset_id);
-			assert_eq!(merged_im.balance(), 100);
+			assert_eq!(merged_im.peek(), 100);
 			// subsume
 			let mut positive_im = PositiveImbalanceOf::zero();
 			let other = PositiveImbalanceOf::new(100, asset_id);
 			positive_im.subsume(other);
 			assert_eq!(positive_im.asset_id(), asset_id);
-			assert_eq!(positive_im.balance(), 100);
+			assert_eq!(positive_im.peek(), 100);
 			// offset
 			let negative_im = PositiveImbalanceOf::new(100, 0);
 			let opposite_im = NegativeImbalanceOf::new(50, asset_id);
 			let offset_im = negative_im.offset(opposite_im).unwrap();
 			assert_eq!(offset_im.asset_id(), asset_id);
-			assert_eq!(offset_im.balance(), 50);
+			assert_eq!(offset_im.peek(), 50);
 	});
 }
 


### PR DESCRIPTION
This PR try to improve the Positive/NegativeImbalance so they are fully compatible with our Generic Asset module

## Changes
* In `merge`, `subsume` and `offset` functions for both `NegativeImbalance` and `NegativeImbalance`:
    - imbalances without asset ID will take on the asset ID of input parameter.
    - These operation will not happen if asset_ids do not match

## Tests
- If imBalance is initialised by `zero` function, asset_id should be updated when calling `merge`, `subsume` or `offset` function.
- Should panic under debug env if asset_id is not consistent when calling `merge`, `subsume` or `offset` function.
- `total_issuance` should be updated after imBalance dropped.
