### PR TITLE
Made some improvements according to the "General" section of the Generic

### DIFF
--- a/frame/generic-asset/src/impls.rs
+++ b/frame/generic-asset/src/impls.rs
@@ -92,9 +92,9 @@ impl<T: Trait> MultiCurrencyAccounting for Module<T> {
 		let asset_id = &currency.unwrap_or_else(|| Self::DefaultCurrencyId::asset_id());
 		let original = <Module<T>>::free_balance(asset_id, who);
 		let imbalance = if original <= balance {
-			SignedImbalance::Positive(Self::PositiveImbalance::new(balance - original, *asset_id))
+			SignedImbalance::Positive(Self::PositiveImbalance::new(balance - original, Some(*asset_id)))
 		} else {
-			SignedImbalance::Negative(Self::NegativeImbalance::new(original - balance, *asset_id))
+			SignedImbalance::Negative(Self::NegativeImbalance::new(original - balance, Some(*asset_id)))
 		};
 		<Module<T>>::set_free_balance(&asset_id, who, balance);
 		(imbalance, UpdateBalanceOutcome::Updated)
@@ -130,7 +130,7 @@ impl<T: Trait> MultiCurrencyAccounting for Module<T> {
 		<Module<T>>::ensure_can_withdraw(asset_id, who, value, reasons, new_balance)?;
 		<Module<T>>::set_free_balance(asset_id, who, new_balance);
 
-		Ok(Self::NegativeImbalance::new(value, *asset_id))
+		Ok(Self::NegativeImbalance::new(value, Some(*asset_id)))
 	}
 }
 

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -191,7 +191,6 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 }
 
-
 pub trait Subtrait: frame_system::Trait {
 	type Balance: Parameter
 		+ Member

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -1031,7 +1031,7 @@ mod imbalances {
 			}
 		}
 		fn offset(self, other: Self::Opposite) -> result::Result<Self, Self::Opposite> {
-			let asset_id = if self.1.is_none() { other.1 } else { self.1 };
+			let asset_id = self.1.or(other.1);
 			if asset_id != other.1 {
 				debug_assert!(false, "Asset ID do not match!");
 				Ok(self)

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -168,7 +168,7 @@ use frame_support::{
 		Currency, ExistenceRequirement, Imbalance, LockIdentifier, LockableCurrency, ReservableCurrency,
 		SignedImbalance, UpdateBalanceOutcome, WithdrawReason, WithdrawReasons, TryDrop,
 	},
-	additional_traits::{AssetIdAuthority, DummyDispatchVerifier, InherentAssetIdProvider},
+	additional_traits::{AssetIdAuthority, DummyDispatchVerifier},
 	Parameter, StorageMap,
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
@@ -914,13 +914,13 @@ impl<T: Trait> Module<T> {
 // of the inner member.
 mod imbalances {
 	use super::{
-		result, Imbalance, InherentAssetIdProvider, Saturating, StorageMap, Subtrait, Trait, Zero, TryDrop,
+		result, Imbalance, Saturating, StorageMap, Subtrait, Trait, Zero, TryDrop,
 	};
 	use sp_std::mem;
 
 	/// Provide access to asset ID within imbalance structs
 	pub trait ImbalanceWithAssetId<T: Subtrait>{
-		fn get_asset_id(&self) -> Option<T::AssetId>;
+		fn asset_id(&self) -> Option<T::AssetId>;
 		fn set_asset_id(&mut self, asset_id : Option<T::AssetId>);
 
 		/// This is a helper function that checks the consistency of asset ID for operations on Imbalances
@@ -931,8 +931,8 @@ mod imbalances {
 		/// Otherwise return true
 		fn match_asset_id(&mut self, other: &Self) -> bool {
 			let mut result = true;
-			match (self.get_asset_id(), other.get_asset_id()) {
-				(None, Some(asset_id)) => self.set_asset_id(other.get_asset_id()),
+			match (self.asset_id(), other.asset_id()) {
+				(None, Some(asset_id)) => self.set_asset_id(other.asset_id()),
 				(Some(this_asset), Some(other_asset)) => {
 					if this_asset != other_asset {
 						debug_assert!(false, "Asset ID do not match!");
@@ -950,18 +950,24 @@ mod imbalances {
 	/// funds have been created without any equal and opposite accounting.
 	#[must_use]
 	#[cfg_attr(test, derive(PartialEq, Debug))]
-	pub struct PositiveImbalance<T: Subtrait>(T::Balance, Option<T::AssetId>);
+	pub struct PositiveImbalance<T: Subtrait> {
+		amount: T::Balance,
+		asset_id: Option<T::AssetId>,
+	}
 	impl<T: Subtrait> PositiveImbalance<T> {
 		pub fn new(amount: T::Balance, asset_id: Option<T::AssetId>) -> Self {
-			PositiveImbalance(amount, asset_id)
+			PositiveImbalance{amount, asset_id}
 		}
 	}
 	impl<T: Subtrait> ImbalanceWithAssetId<T> for PositiveImbalance<T>{
-		fn get_asset_id(&self) -> Option<T::AssetId> {
-			self.1
+		fn asset_id(&self) -> Option<T::AssetId> {
+			self.asset_id
 		}
 		fn set_asset_id(&mut self, asset_id : Option<T::AssetId>){
-			self.1 = asset_id;
+			match self.asset_id {
+				Some(asset_id) => debug_assert!(false, "Asset id already set"),
+				None => self.asset_id = asset_id,
+			}
 		}
 	}
 
@@ -969,19 +975,25 @@ mod imbalances {
 	/// funds have been destroyed without any equal and opposite accounting.
 	#[must_use]
 	#[cfg_attr(test, derive(PartialEq, Debug))]
-	pub struct NegativeImbalance<T: Subtrait>(T::Balance, Option<T::AssetId>);
+	pub struct NegativeImbalance<T: Subtrait>{
+		amount: T::Balance,
+		asset_id: Option<T::AssetId>,
+	}
 	impl<T: Subtrait> NegativeImbalance<T> {
 		pub fn new(amount: T::Balance, asset_id: Option<T::AssetId>) -> Self {
-			NegativeImbalance(amount, asset_id)
+			NegativeImbalance{amount, asset_id}
 		}
 	}
 
 	impl<T: Subtrait> ImbalanceWithAssetId<T> for NegativeImbalance<T> {
-		fn get_asset_id(&self) -> Option<T::AssetId> {
-			self.1
+		fn asset_id(&self) -> Option<T::AssetId> {
+			self.asset_id
 		}
 		fn set_asset_id(&mut self, asset_id: Option<T::AssetId>) {
-			self.1 = asset_id;
+			match self.asset_id {
+				Some(asset_id) => debug_assert!(false, "Asset id already set"),
+				None => self.asset_id = asset_id,
+			}
 		}
 	}
 
@@ -1001,16 +1013,16 @@ mod imbalances {
 			Self::new(Zero::zero(), None)
 		}
 		fn drop_zero(self) -> result::Result<(), Self> {
-			if self.0.is_zero() {
+			if self.amount.is_zero() {
 				Ok(())
 			} else {
 				Err(self)
 			}
 		}
 		fn split(self, amount: T::Balance) -> (Self, Self) {
-			let first = self.0.min(amount);
-			let second = self.0 - first;
-			let asset_id = self.1;
+			let first = self.amount.min(amount);
+			let second = self.amount - first;
+			let asset_id = self.asset_id;
 
 			mem::forget(self);
 			(Self::new(first, asset_id), Self::new(second, asset_id))
@@ -1018,7 +1030,7 @@ mod imbalances {
 		fn merge(mut self, other: Self) -> Self {
 			// Only merge when asset_id match
 			if self.match_asset_id(&other) {
-				self.0 = self.0.saturating_add(other.0);
+				self.amount = self.amount.saturating_add(other.amount);
 				mem::forget(other);
 			}
 			self
@@ -1026,17 +1038,17 @@ mod imbalances {
 		fn subsume(&mut self, other: Self) {
 			// Only subsume when asset_id match
 			if self.match_asset_id(&other) {
-				self.0 = self.0.saturating_add(other.0);
+				self.amount = self.amount.saturating_add(other.amount);
 				mem::forget(other);
 			}
 		}
 		fn offset(self, other: Self::Opposite) -> result::Result<Self, Self::Opposite> {
-			let asset_id = if self.1.is_none() { other.1 } else { self.1 };
-			if asset_id != other.1 {
+			let asset_id = if self.asset_id.is_none() { other.asset_id } else { self.asset_id };
+			if asset_id != other.asset_id {
 				debug_assert!(false, "Asset ID do not match!");
 				Ok(self)
 			} else {
-				let (a, b) = (self.0, other.0);
+				let (a, b) = (self.amount, other.amount);
 				mem::forget((self, other));
 
 				if a >= b {
@@ -1047,7 +1059,7 @@ mod imbalances {
 			}
 		}
 		fn peek(&self) -> T::Balance {
-			self.0.clone()
+			self.amount.clone()
 		}
 	}
 
@@ -1064,16 +1076,16 @@ mod imbalances {
 			Self::new(Zero::zero(), None)
 		}
 		fn drop_zero(self) -> result::Result<(), Self> {
-			if self.0.is_zero() {
+			if self.amount.is_zero() {
 				Ok(())
 			} else {
 				Err(self)
 			}
 		}
 		fn split(self, amount: T::Balance) -> (Self, Self) {
-			let first = self.0.min(amount);
-			let second = self.0 - first;
-			let asset_id = self.1;
+			let first = self.amount.min(amount);
+			let second = self.amount - first;
+			let asset_id = self.asset_id;
 
 			mem::forget(self);
 			(Self::new(first, asset_id), Self::new(second, asset_id))
@@ -1081,26 +1093,25 @@ mod imbalances {
 		fn merge(mut self, other: Self) -> Self {
 			// Only merge when asset_id match
 			if self.match_asset_id(&other) {
-				self.0 = self.0.saturating_add(other.0);
+				self.amount = self.amount.saturating_add(other.amount);
 				mem::forget(other);
 			}
-
 			self
 		}
 		fn subsume(&mut self, other: Self) {
 			// Only subsume when asset_id match
 			if self.match_asset_id(&other) {
-				self.0 = self.0.saturating_add(other.0);
+				self.amount = self.amount.saturating_add(other.amount);
 				mem::forget(other);
 			}
 		}
 		fn offset(self, other: Self::Opposite) -> result::Result<Self, Self::Opposite> {
-			let asset_id = if self.1.is_none() { other.1 } else { self.1 };
-			if asset_id != other.1 {
+			let asset_id = if self.asset_id.is_none() { other.asset_id } else { self.asset_id };
+			if asset_id != other.asset_id {
 				debug_assert!(false, "Asset ID do not match!");
 				Ok(self)
 			} else {
-				let (a, b) = (self.0, other.0);
+				let (a, b) = (self.amount, other.amount);
 				mem::forget((self, other));
 
 				if a >= b {
@@ -1111,15 +1122,15 @@ mod imbalances {
 			}
 		}
 		fn peek(&self) -> T::Balance {
-			self.0.clone()
+			self.amount.clone()
 		}
 	}
 
 	impl<T: Subtrait> Drop for PositiveImbalance<T> {
 		/// Basic drop handler will just square up the total issuance.
 		fn drop(&mut self) {
-			if let Some(asset_id) = self.1 {
-				<super::TotalIssuance<super::ElevatedTrait<T>>>::mutate(asset_id, |v| *v = v.saturating_add(self.0));
+			if let Some(asset_id) = self.asset_id {
+				<super::TotalIssuance<super::ElevatedTrait<T>>>::mutate(asset_id, |v| *v = v.saturating_add(self.amount));
 			}
 		}
 	}
@@ -1127,23 +1138,9 @@ mod imbalances {
 	impl<T: Subtrait> Drop for NegativeImbalance<T> {
 		/// Basic drop handler will just square up the total issuance.
 		fn drop(&mut self) {
-			if let Some(asset_id) = self.1 {
-				<super::TotalIssuance<super::ElevatedTrait<T>>>::mutate(&asset_id, |v| *v = v.saturating_sub(self.0));
+			if let Some(asset_id) = self.asset_id {
+				<super::TotalIssuance<super::ElevatedTrait<T>>>::mutate(&asset_id, |v| *v = v.saturating_sub(self.amount));
 			}
-		}
-	}
-
-	impl<T: Trait> InherentAssetIdProvider for PositiveImbalance<T> {
-		type AssetId = T::AssetId;
-		fn asset_id(&self) -> Option<Self::AssetId> {
-			self.1
-		}
-	}
-
-	impl<T: Trait> InherentAssetIdProvider for NegativeImbalance<T> {
-		type AssetId = T::AssetId;
-		fn asset_id(&self) -> Option<Self::AssetId> {
-			self.1
 		}
 	}
 }

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -1459,7 +1459,7 @@ fn positive_imbalance_operations_with_incompatible_asset_id_should_not_work() {
 		// will not subsume `other` into `negative_im` due to incompatible asset_id
 		let other = PositiveImbalanceOf::new(50, Some(2));
 		positive_im.subsume(other);
-		assert_eq!(positive_im.asset_id(), Some(asset_id()));
+		assert_eq!(positive_im.asset_id(), Some(asset_id));
 		assert_eq!(positive_im.peek(), 100);
 
 		// will not offset `negative_im` with `opposite_im` due to incompatible asset_id

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -22,7 +22,9 @@
 
 use super::*;
 use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, System, Test, TestEvent, PositiveImbalanceOf, NegativeImbalanceOf};
+use crate::imbalances::ImbalanceWithAssetId;
 use frame_support::{assert_noop, assert_ok, traits::Imbalance};
+
 
 #[test]
 fn issuing_asset_units_to_issuer_should_work() {

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -1254,39 +1254,39 @@ fn zero_asset_id_should_updated_after_negative_imbalance_operations() {
 		.execute_with(|| {
 			// generate empty negative imbalance
 			let negative_im = NegativeImbalanceOf::zero();
-			let other = NegativeImbalanceOf::new(100, asset_id);
-			assert_eq!(negative_im.asset_id(), 0);
+			let other = NegativeImbalanceOf::new(100, Some(asset_id));
+			assert_eq!(negative_im.asset_id(), None);
 			assert_eq!(negative_im.peek(), 0);
-			assert_eq!(other.asset_id(), asset_id);
+			assert_eq!(other.asset_id(), Some(asset_id));
 			// zero asset id should updated after merge
 			let merged_im = negative_im.merge(other);
-			assert_eq!(merged_im.asset_id(), asset_id);
+			assert_eq!(merged_im.asset_id(), Some(asset_id));
 			assert_eq!(merged_im.peek(), 100);
 			// merge other with same asset id should work
-			let other = NegativeImbalanceOf::new(100, asset_id);
+			let other = NegativeImbalanceOf::new(100, Some(asset_id));
 			let merged_im = merged_im.merge(other);
 			assert_eq!(merged_im.peek(), 200);
 
 			// zero asset id should updated after subsume
 			let mut negative_im = NegativeImbalanceOf::zero();
-			let other = NegativeImbalanceOf::new(100, asset_id);
-			assert_eq!(negative_im.asset_id(), 0);
+			let other = NegativeImbalanceOf::new(100, Some(asset_id));
+			assert_eq!(negative_im.asset_id(), None);
 			negative_im.subsume(other);
-			assert_eq!(negative_im.asset_id(), asset_id);
+			assert_eq!(negative_im.asset_id(),Some(asset_id));
 			assert_eq!(negative_im.peek(), 100);
 			// subsume other with same asset id should work
-			let other = NegativeImbalanceOf::new(100, asset_id);
+			let other = NegativeImbalanceOf::new(100, Some(asset_id));
 			negative_im.subsume(other);
 			assert_eq!(negative_im.peek(), 200);
 
-			// zero asset id should updated after offset with opposite im
-			let negative_im = NegativeImbalanceOf::new(100, 0);
-			let opposite_im = PositiveImbalanceOf::new(50, asset_id);
+			// None asset id should updated after offset with opposite im
+			let negative_im = NegativeImbalanceOf::new(100, None);
+			let opposite_im = PositiveImbalanceOf::new(50, Some(asset_id));
 			let offset_im = negative_im.offset(opposite_im).unwrap();
-			assert_eq!(offset_im.asset_id(), asset_id);
+			assert_eq!(offset_im.asset_id(), Some(asset_id));
 			assert_eq!(offset_im.peek(), 50);
 			// offset opposite im with same asset id should work
-			let opposite_im = PositiveImbalanceOf::new(25, asset_id);
+			let opposite_im = PositiveImbalanceOf::new(25, Some(asset_id));
 			let offset_im = offset_im.offset(opposite_im).unwrap();
 			assert_eq!(offset_im.peek(), 25);
 		});
@@ -1300,37 +1300,37 @@ fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
 		.execute_with(|| {
 			// generate empty positive imbalance
 			let positive_im = PositiveImbalanceOf::zero();
-			let other = PositiveImbalanceOf::new(100, asset_id);
-			assert_eq!(positive_im.asset_id(), 0);
+			let other = PositiveImbalanceOf::new(100, Some(asset_id));
+			assert_eq!(positive_im.asset_id(), None);
 			assert_eq!(positive_im.peek(), 0);
 			// zero asset id should updated after merge
 			let merged_im = positive_im.merge(other);
-			assert_eq!(merged_im.asset_id(), asset_id);
+			assert_eq!(merged_im.asset_id(), Some(asset_id));
 			assert_eq!(merged_im.peek(), 100);
 			// merge other with same asset id should work
-			let other = PositiveImbalanceOf::new(100, asset_id);
+			let other = PositiveImbalanceOf::new(100, Some(asset_id));
 			let merged_im = merged_im.merge(other);
 			assert_eq!(merged_im.peek(), 200);
 			
 			// subsume
 			let mut positive_im = PositiveImbalanceOf::zero();
-			let other = PositiveImbalanceOf::new(100, asset_id);
+			let other = PositiveImbalanceOf::new(100, Some(asset_id));
 			positive_im.subsume(other);
-			assert_eq!(positive_im.asset_id(), asset_id);
+			assert_eq!(positive_im.asset_id(), Some(asset_id));
 			assert_eq!(positive_im.peek(), 100);
 			// subsume other with same asset id should work
-			let other = PositiveImbalanceOf::new(100, asset_id);
+			let other = PositiveImbalanceOf::new(100, Some(asset_id));
 			positive_im.subsume(other);
 			assert_eq!(positive_im.peek(), 200);
 			
 			// zero asset id should updated after offset with opposite im
-			let negative_im = PositiveImbalanceOf::new(100, 0);
-			let opposite_im = NegativeImbalanceOf::new(50, asset_id);
+			let negative_im = PositiveImbalanceOf::new(100, None);
+			let opposite_im = NegativeImbalanceOf::new(50, Some(asset_id));
 			let offset_im = negative_im.offset(opposite_im).unwrap();
-			assert_eq!(offset_im.asset_id(), asset_id);
+			assert_eq!(offset_im.asset_id(), Some(asset_id));
 			assert_eq!(offset_im.peek(), 50);
 			// offset opposite im with same asset id should work
-			let opposite_im = NegativeImbalanceOf::new(25, asset_id);
+			let opposite_im = NegativeImbalanceOf::new(25, Some(asset_id));
 			let offset_im = offset_im.offset(opposite_im).unwrap();
 			assert_eq!(offset_im.peek(), 25);
 	});
@@ -1339,11 +1339,11 @@ fn zero_asset_id_should_updated_after_positive_imbalance_operations() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn negative_imbalance_merge_with_imcompatible_asset_id_should_fail() {
+fn negative_imbalance_merge_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let negative_im = NegativeImbalanceOf::new(100, 1);
-		let other = NegativeImbalanceOf::new(50, 2);
+		let negative_im = NegativeImbalanceOf::new(100, Some(1));
+		let other = NegativeImbalanceOf::new(50, Some(2));
 		// merge
 		let _ = negative_im.merge(other);
 	});
@@ -1352,11 +1352,11 @@ fn negative_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn positive_imbalance_merge_with_imcompatible_asset_id_should_fail() {
+fn positive_imbalance_merge_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let positive_im = PositiveImbalanceOf::new(100, 1);
-		let other = PositiveImbalanceOf::new(50, 2);
+		let positive_im = PositiveImbalanceOf::new(100, Some(1));
+		let other = PositiveImbalanceOf::new(50, Some(2));
 		// merge
 		let _ = positive_im.merge(other);
 	});
@@ -1365,11 +1365,11 @@ fn positive_imbalance_merge_with_imcompatible_asset_id_should_fail() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn negative_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
+fn negative_imbalance_subsume_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let mut negative_im = NegativeImbalanceOf::new(100, 1);
-		let other = NegativeImbalanceOf::new(50, 2);
+		let mut negative_im = NegativeImbalanceOf::new(100, Some(1));
+		let other = NegativeImbalanceOf::new(50, Some(2));
 		// merge
 		negative_im.subsume(other);
 	});
@@ -1378,11 +1378,11 @@ fn negative_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn positive_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
+fn positive_imbalance_subsume_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let mut positive_im = PositiveImbalanceOf::new(100, 1);
-		let other = PositiveImbalanceOf::new(50, 2);
+		let mut positive_im = PositiveImbalanceOf::new(100, Some(1));
+		let other = PositiveImbalanceOf::new(50, Some(2));
 		// merge
 		positive_im.subsume(other);
 	});
@@ -1391,11 +1391,11 @@ fn positive_imbalance_subsume_with_imcompatible_asset_id_should_fail() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn negative_imbalance_offset_with_imcompatible_asset_id_should_fail() {
+fn negative_imbalance_offset_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let negative_im = NegativeImbalanceOf::new(100, 1);
-		let opposite_im = PositiveImbalanceOf::new(50, 2);
+		let negative_im = NegativeImbalanceOf::new(100, Some(1));
+		let opposite_im = PositiveImbalanceOf::new(50, Some(2));
 		let _ = negative_im.offset(opposite_im);
 	});
 }
@@ -1403,69 +1403,69 @@ fn negative_imbalance_offset_with_imcompatible_asset_id_should_fail() {
 #[test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "Asset ID do not match!")]
-fn positive_imbalance_offset_with_imcompatible_asset_id_should_fail() {
+fn positive_imbalance_offset_with_incompatible_asset_id_should_fail() {
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalances with different asset id
-		let positive_im = PositiveImbalanceOf::new(100, 1);
-		let opposite_im = NegativeImbalanceOf::new(50, 2);
+		let positive_im = PositiveImbalanceOf::new(100, Some(1));
+		let opposite_im = NegativeImbalanceOf::new(50, Some(2));
 		let _ = positive_im.offset(opposite_im);
 	});
 }
 
 // In release version, negative imblance do any operations (`merge`, `subsume` or `offset`)
-// with imcompatible asset_id should not working, it will return the original negative imbalance.
+// with incompatible asset_id should not working, it will return the original negative imbalance.
 #[test]
 #[cfg(not(debug_assertions))]
-fn negative_imbalance_operations_with_imcompatible_asset_id_should_not_work() {
+fn negative_imbalance_operations_with_incompatible_asset_id_should_not_work() {
 	let asset_id = 16000;
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalance with different asset id
-		let negative_im = NegativeImbalanceOf::new(100, asset_id);
-		let other = NegativeImbalanceOf::new(50, 2);
-		// will not merge `other` into `negative_im` due to imcompatible asset_id
+		let negative_im = NegativeImbalanceOf::new(100, Some(asset_id));
+		let other = NegativeImbalanceOf::new(50, Some(2));
+		// will not merge `other` into `negative_im` due to incompatible asset_id
 		let mut negative_im = negative_im.merge(other);
-		assert_eq!(negative_im.asset_id(), asset_id);
+		assert_eq!(negative_im.asset_id(), Some(asset_id));
 		assert_eq!(negative_im.peek(), 100);
 
-		// will not subsume `other` into `negative_im` due to imcompatible asset_id
-		let other = NegativeImbalanceOf::new(50, 2);
+		// will not subsume `other` into `negative_im` due to incompatible asset_id
+		let other = NegativeImbalanceOf::new(50, Some(2));
 		negative_im.subsume(other);
-		assert_eq!(negative_im.asset_id(), asset_id);
+		assert_eq!(negative_im.asset_id(), Some(asset_id));
 		assert_eq!(negative_im.peek(), 100);
 
-		// will not offset `negative_im` with `opposite_im` due to imcompatible asset_id
-		let opposite_im = PositiveImbalanceOf::new(50, 2);
+		// will not offset `negative_im` with `opposite_im` due to incompatible asset_id
+		let opposite_im = PositiveImbalanceOf::new(50, Some(2));
 		let negative_im = negative_im.offset(opposite_im).unwrap();
-		assert_eq!(negative_im.asset_id(), asset_id);
+		assert_eq!(negative_im.asset_id(), Some(asset_id));
 		assert_eq!(negative_im.peek(), 100);
 	});
 }
 
 // In release version, positive imblance do any operations (`merge`, `subsume` or `offset`)
-// with imcompatible asset_id should not working, it will return the original positive imbalance.
+// with incompatible asset_id should not working, it will return the original positive imbalance.
 #[test]
 #[cfg(not(debug_assertions))]
-fn positive_imbalance_operations_with_imcompatible_asset_id_should_not_work() {
+fn positive_imbalance_operations_with_incompatible_asset_id_should_not_work() {
 	let asset_id = 16000;
 	ExtBuilder::default().build().execute_with(|| {
 		// create two mew imbalance with different asset id
-		let positive_im = PositiveImbalanceOf::new(100, asset_id);
-		let other = PositiveImbalanceOf::new(50, 2);
-		// will not merge `other` into `negative_im` due to imcompatible asset_id
+		let positive_im = PositiveImbalanceOf::new(100, Some(asset_id));
+		let other = PositiveImbalanceOf::new(50, Some(2));
+		// will not merge `other` into `negative_im` due to incompatible asset_id
 		let mut positive_im = positive_im.merge(other);
-		assert_eq!(positive_im.asset_id(), asset_id);
+		assert_eq!(positive_im.asset_id(), Some(asset_id));
 		assert_eq!(positive_im.peek(), 100);
 
-		// will not subsume `other` into `negative_im` due to imcompatible asset_id
-		let other = PositiveImbalanceOf::new(50, 2);
+		// will not subsume `other` into `negative_im` due to incompatible asset_id
+		let other = PositiveImbalanceOf::new(50, Some(2));
 		positive_im.subsume(other);
-		assert_eq!(positive_im.asset_id(), asset_id);
+		assert_eq!(positive_im.asset_id(), Some(asset_id()));
 		assert_eq!(positive_im.peek(), 100);
 
-		// will not offset `negative_im` with `opposite_im` due to imcompatible asset_id
-		let opposite_im = NegativeImbalanceOf::new(50, 2);
+		// will not offset `negative_im` with `opposite_im` due to incompatible asset_id
+		let opposite_im = NegativeImbalanceOf::new(50, Some(2));
 		let positive_im = positive_im.offset(opposite_im).unwrap();
-		assert_eq!(positive_im.asset_id(), asset_id);
+		assert_eq!(positive_im.asset_id(), Some(asset_id));
 		assert_eq!(positive_im.peek(), 100);
 	});
 }
@@ -1481,7 +1481,7 @@ fn total_issuance_should_update_after_positive_imbalance_dropped() {
 			assert_eq!(GenericAsset::total_issuance(&asset_id), balance);
 			// generate empty positive imbalance
 			let positive_im = PositiveImbalanceOf::zero();
-			let other = PositiveImbalanceOf::new(100, asset_id);
+			let other = PositiveImbalanceOf::new(100, Some(asset_id));
 			// merge
 			let merged_im = positive_im.merge(other);
 			// explitically drop `imbalance` so issuance is managed
@@ -1501,7 +1501,7 @@ fn total_issuance_should_update_after_negative_imbalance_dropped() {
 			assert_eq!(GenericAsset::total_issuance(&asset_id), balance);
 			// generate empty positive imbalance
 			let positive_im = NegativeImbalanceOf::zero();
-			let other = NegativeImbalanceOf::new(100, asset_id);
+			let other = NegativeImbalanceOf::new(100, Some(asset_id));
 			// merge
 			let merged_im = positive_im.merge(other);
 			// explitically drop `imbalance` so issuance is managed

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -69,7 +69,7 @@ fn issuing_with_next_asset_id_overflow_should_not_work() {
 					permissions: default_permission
 				}
 			),
-			Error::<Test>::NoAssetIdAvailable
+			Error::<Test>::AssetIdExhausted
 		);
 		assert_eq!(GenericAsset::next_asset_id(), u32::max_value());
 	});
@@ -1020,7 +1020,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 					permissions: default_permission.clone()
 				}
 			),
-			Error::<Test>::AssetIdAlreadyTaken,
+			Error::<Test>::AssetIdExists,
 		);
 	});
 }

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -67,7 +67,7 @@ fn issuing_with_next_asset_id_overflow_should_not_work() {
 					permissions: default_permission
 				}
 			),
-			Error::<Test>::NoIdAvailable
+			Error::<Test>::NoAssetIdAvailable
 		);
 		assert_eq!(GenericAsset::next_asset_id(), u32::max_value());
 	});
@@ -976,7 +976,7 @@ fn create_asset_with_non_reserved_asset_id_should_not_work() {
 					permissions: default_permission.clone()
 				}
 			),
-			Error::<Test>::IdUnavailable,
+			Error::<Test>::AssetIdUnavailable,
 		);
 	});
 }
@@ -1018,7 +1018,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 					permissions: default_permission.clone()
 				}
 			),
-			Error::<Test>::IdAlreadyTaken,
+			Error::<Test>::AssetIdAlreadyTaken,
 		);
 	});
 }

--- a/frame/support/src/additional_traits.rs
+++ b/frame/support/src/additional_traits.rs
@@ -302,5 +302,5 @@ pub trait InherentAssetIdProvider {
 	/// The asset ID type e.g. a `u32`
 	type AssetId;
 	/// Return the inherent asset ID
-	fn asset_id(&self) -> Self::AssetId;
+	fn asset_id(&self) -> Option<Self::AssetId>;
 }

--- a/frame/support/src/additional_traits.rs
+++ b/frame/support/src/additional_traits.rs
@@ -295,12 +295,3 @@ pub trait AssetIdAuthority {
 	fn asset_id() -> Self::AssetId;
 }
 
-/// A type which can provide it's inherent asset ID
-/// It is useful in the context of an asset/currency aware balance type
-/// It differs from `AssetIdAuthority` in that it is not statically defined
-pub trait InherentAssetIdProvider {
-	/// The asset ID type e.g. a `u32`
-	type AssetId;
-	/// Return the inherent asset ID
-	fn asset_id(&self) -> Option<Self::AssetId>;
-}


### PR DESCRIPTION
General section:
* Made asset id of 0 the "null_asset_id"
* Improved some error names
* Check for target account overflow in make_transfer

Imbalance section
* Asset Id for imbalances cannot be changed once it is set
* Imbalances now have named fields
* Removed the InherentAssetIdProvider