### PR TITLE
Refactor/ga intergration test

### DIFF
--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -31,6 +31,23 @@ use frame_support::{parameter_types, impl_outer_event, impl_outer_origin, weight
 
 use super::*;
 
+// test accounts
+pub const ALICE: u64 = 1;
+pub const BOB: u64 = 2;
+pub const CHARLIE: u64 = 3;
+
+// staking asset id
+pub const STAKING_ASSET_ID: u32 = 16000;
+// spending asset id
+pub const SPENDING_ASSET_ID: u32 = 16001;
+// default next asset id
+pub const ASSET_ID: u32 = 1000;
+
+// initial issuance for creating new asset
+pub const INITIAL_ISSUANCE: u64 = 1000;
+// iniital balance for seting free balance
+pub const INITIAL_BALANCE: u64 = 100;
+
 impl_outer_origin! {
 	pub enum Origin for Test  where system = frame_system {}
 }
@@ -105,7 +122,7 @@ impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
 			asset_id: 0,
-			next_asset_id: 1000,
+			next_asset_id: ASSET_ID,
 			accounts: vec![0],
 			initial_balance: 0,
 			permissions: vec![],
@@ -141,8 +158,8 @@ impl ExtBuilder {
 				endowed_accounts: self.accounts,
 				initial_balance: self.initial_balance,
 				next_asset_id: self.next_asset_id,
-				staking_asset_id: 16000,
-				spending_asset_id: 16001,
+				staking_asset_id: STAKING_ASSET_ID,
+				spending_asset_id: SPENDING_ASSET_ID,
 				permissions: self.permissions,
 			}
 			.assimilate_storage(&mut t).unwrap();

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -551,21 +551,32 @@ fn create_reserved_should_create_a_default_account_with_the_balance_given() {
 }
 
 #[test]
-fn create_reserved_with_invalid_asset_id_should_failed() {
+fn create_reserved_with_non_reserved_asset_id_should_failed() {
 	let amount = 500;
 	let account = 0;
-	let asset_id = 10;
-	ExtBuilder::default().next_asset_id(asset_id).build().execute_with(|| {
+	let asset_id = 11;
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
 		let options = asset_options(amount, permissions);
 
-		// create reserved asset with existing asset_id >= next_asset_id should fail
+		// create reserved asset with asset_id >= next_asset_id should fail
 		assert_noop!(
 			GenericAsset::create_reserved(Origin::ROOT, asset_id, options.clone()),
 			Error::<Test>::IdUnavailable,
 		);
+	});
+}
+
+#[test]
+fn create_reserved_with_a_taken_asset_id_should_failed() {
+	let amount = 500;
+	let account = 0;
+	let asset_id = 9;
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
+		let permissions = PermissionLatest::new(1);
+		let options = asset_options(amount, permissions);
+		
 		// create reserved asset with asset_id < next_asset_id should success
-		let asset_id = 9;
 		assert_ok!(GenericAsset::create_reserved(Origin::ROOT, asset_id, options.clone()));
 		assert_eq!(<TotalIssuance<Test>>::get(asset_id), amount);
 		// all reserved assets belong to account: 0 which is the default value of `AccountId`

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -29,12 +29,7 @@ fn issuing_asset_units_to_issuer_should_work() {
 	let balance = 100;
 
 	ExtBuilder::default().free_balance((16000, 1, 100)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
-
+		let default_permissions = PermissionLatest::new(1);
 		let expected_balance = balance;
 
 		assert_ok!(GenericAsset::create(
@@ -42,7 +37,7 @@ fn issuing_asset_units_to_issuer_should_work() {
 			1,
 			AssetOptions {
 				initial_issuance: balance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_eq!(GenericAsset::free_balance(&16000, &1), expected_balance);
@@ -53,18 +48,15 @@ fn issuing_asset_units_to_issuer_should_work() {
 fn issuing_with_next_asset_id_overflow_should_not_work() {
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		NextAssetId::<Test>::put(u32::max_value());
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_noop!(
 			GenericAsset::create(
 				Origin::ROOT,
 				1,
 				AssetOptions {
 					initial_issuance: 1,
-					permissions: default_permission
+					permissions: default_permissions
 				}
 			),
 			Error::<Test>::NoIdAvailable
@@ -78,17 +70,14 @@ fn querying_total_supply_should_work() {
 	let asset_id = 1000;
 
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 	  assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: 100,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
@@ -124,17 +113,14 @@ fn transferring_amount_should_work() {
 	let asset_id = 1000;
 	let free_balance = 100;
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: free_balance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &1), free_balance);
@@ -163,17 +149,14 @@ fn transferring_amount_should_work() {
 fn transferring_amount_should_fail_when_transferring_more_than_free_balance() {
 	let asset_id = 1000;
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: 100,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_noop!(
@@ -188,17 +171,14 @@ fn transferring_less_than_one_unit_should_not_work() {
 	let asset_id = 1000;
 
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: 100,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
@@ -224,17 +204,14 @@ fn self_transfer_should_fail() {
 	let balance = 100;
 
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: balance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 
@@ -248,17 +225,14 @@ fn self_transfer_should_fail() {
 fn transferring_more_units_than_total_supply_should_not_work() {
 	let asset_id = 1000;
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: 100,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
@@ -304,20 +278,17 @@ fn total_balance_should_be_zero() {
 // -Â total_balance should equals to reserved balance.
 #[test]
 fn total_balance_should_be_equal_to_account_balance() {
-	let default_permission = PermissionLatest {
-		update: Owner::Address(1),
-		mint: Owner::Address(1),
-		burn: Owner::Address(1),
-	};
+	let default_permissions = PermissionLatest::new(1);
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: 100,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
+
 		assert_eq!(GenericAsset::total_balance(&1000, &1), 100);
 	});
 }
@@ -593,14 +564,11 @@ fn repatriate_reserved_return_none() {
 #[test]
 fn create_reserved_should_create_a_default_account_with_the_balance_given() {
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
-		let default_permission = PermissionLatest {
-			update: Owner::Address(1),
-			mint: Owner::Address(1),
-			burn: Owner::Address(1),
-		};
+		let default_permissions = PermissionLatest::new(1);
+
 		let options = AssetOptions {
 			initial_issuance: 500,
-			permissions: default_permission,
+			permissions: default_permissions,
 		};
 
 		let expected_total_issuance = 500;
@@ -656,19 +624,14 @@ fn mint_should_increase_asset() {
 		let to_account = 2;
 		let amount = 500;
 		let initial_issuance = 100;
-
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
+		let default_permissions = PermissionLatest::new(origin);
 
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 
@@ -720,19 +683,14 @@ fn burn_should_burn_an_asset() {
 		let initial_issuance = 100;
 		let burn_amount = 400;
 		let expected_amount = 600;
-
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
+		let default_permissions = PermissionLatest::new(origin);
 
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 		assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
@@ -748,7 +706,7 @@ fn burn_should_burn_an_asset() {
 }
 
 // Given
-// - `default_permission` with all privileges.
+// - `default_permissions` with all privileges.
 // - All permissions for origin.
 // When
 // - After executing create function and check_permission function.
@@ -760,19 +718,14 @@ fn check_permission_should_return_correct_permission() {
 		let origin = 1;
 		let asset_id = 1000;
 		let initial_issuance = 100;
-
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
+		let default_permissions = PermissionLatest::new(origin);
 
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			},
 		));
 
@@ -783,7 +736,7 @@ fn check_permission_should_return_correct_permission() {
 }
 
 // Given
-// - `default_permission` with no privileges.
+// - `default_permissions` with no privileges.
 // - No permissions for origin.
 // When
 // - After executing create function and check_permission function.
@@ -796,18 +749,14 @@ fn check_permission_should_return_false_for_no_permission() {
 		let asset_id = 1000;
 		let initial_issuance = 100;
 
-		let default_permission = PermissionLatest {
-			update: Owner::None,
-			mint: Owner::None,
-			burn: Owner::None,
-		};
+		let default_permissions = PermissionLatest::default();
 
 		assert_ok!(GenericAsset::create(
 			Origin::ROOT,
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 
@@ -818,7 +767,7 @@ fn check_permission_should_return_false_for_no_permission() {
 }
 
 // Given
-// - `default_permission` only with update.
+// - `default_permissions` only with update.
 // When
 // - After executing update_permission function.
 // Then
@@ -831,7 +780,7 @@ fn update_permission_should_change_permission() {
 		let asset_id = 1000;
 		let initial_issuance = 100;
 
-		let default_permission = PermissionLatest {
+		let default_permissions = PermissionLatest {
 			update: Owner::Address(origin),
 			mint: Owner::None,
 			burn: Owner::None,
@@ -848,7 +797,7 @@ fn update_permission_should_change_permission() {
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 
@@ -863,7 +812,7 @@ fn update_permission_should_change_permission() {
 }
 
 // Given
-// - `default_permission` without any permissions.
+// - `default_permissions` without any permissions.
 // When
 // - After executing update_permission function.
 // Then
@@ -875,11 +824,7 @@ fn update_permission_should_throw_error_when_lack_of_permissions() {
 		let asset_id = 1000;
 		let initial_issuance = 100;
 
-		let default_permission = PermissionLatest {
-			update: Owner::None,
-			mint: Owner::None,
-			burn: Owner::None,
-		};
+		let default_permissions = PermissionLatest::default();
 
 		let new_permission = PermissionLatest {
 			update: Owner::Address(origin),
@@ -892,7 +837,7 @@ fn update_permission_should_throw_error_when_lack_of_permissions() {
 			1,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			},
 		));
 
@@ -921,12 +866,8 @@ fn create_asset_works_with_given_asset_id_and_from_account() {
 		let origin = 1;
 		let from_account: Option<<Test as frame_system::Trait>::AccountId> = Some(1);
 
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
-		let expected_permission = PermissionVersions::V1(default_permission.clone());
+		let default_permissions = PermissionLatest::new(origin);
+		let expected_permission = PermissionVersions::V1(default_permissions.clone());
 		let asset_id = 9;
 		let initial_issuance = 100;
 
@@ -935,7 +876,7 @@ fn create_asset_works_with_given_asset_id_and_from_account() {
 			from_account,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission.clone()
+				permissions: default_permissions.clone()
 			}
 		));
 
@@ -957,12 +898,7 @@ fn create_asset_with_non_reserved_asset_id_should_not_work() {
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as frame_system::Trait>::AccountId> = Some(1);
-
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
+		let default_permissions = PermissionLatest::new(origin);
 
 		let asset_id = 11;
 		let initial_issuance = 100;
@@ -973,7 +909,7 @@ fn create_asset_with_non_reserved_asset_id_should_not_work() {
 				from_account,
 				AssetOptions {
 					initial_issuance,
-					permissions: default_permission.clone()
+					permissions: default_permissions.clone()
 				}
 			),
 			Error::<Test>::IdUnavailable,
@@ -992,11 +928,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 		let origin = 1;
 		let from_account: Option<<Test as frame_system::Trait>::AccountId> = Some(1);
 
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
+		let default_permissions = PermissionLatest::new(origin);
 
 		let asset_id = 9;
 		let initial_issuance = 100;
@@ -1006,7 +938,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 			from_account,
 			AssetOptions {
 				initial_issuance,
-				permissions: default_permission.clone()
+				permissions: default_permissions.clone()
 			}
 		));
 		assert_noop!(
@@ -1015,7 +947,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 				from_account,
 				AssetOptions {
 					initial_issuance,
-					permissions: default_permission.clone()
+					permissions: default_permissions.clone()
 				}
 			),
 			Error::<Test>::IdAlreadyTaken,
@@ -1037,12 +969,7 @@ fn create_asset_should_create_a_reserved_asset_when_from_account_is_none() {
 		let origin = 1;
 		let from_account: Option<<Test as frame_system::Trait>::AccountId> = None;
 
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
-
+		let default_permissions = PermissionLatest::new(origin);
 		let created_account_id = 0;
 		let asset_id = 9;
 		let initial_issuance = 100;
@@ -1052,7 +979,7 @@ fn create_asset_should_create_a_reserved_asset_when_from_account_is_none() {
 			from_account,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 
@@ -1079,13 +1006,8 @@ fn create_asset_should_create_a_user_asset() {
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as frame_system::Trait>::AccountId> = None;
-
-		let default_permission = PermissionLatest {
-			update: Owner::Address(origin),
-			mint: Owner::Address(origin),
-			burn: Owner::Address(origin),
-		};
-
+		let default_permissions = PermissionLatest::new(origin);
+		
 		let created_account_id = 0;
 		let reserved_asset_id = 100000;
 		let initial_issuance = 100;
@@ -1096,7 +1018,7 @@ fn create_asset_should_create_a_user_asset() {
 			from_account,
 			AssetOptions {
 				initial_issuance: initial_issuance,
-				permissions: default_permission
+				permissions: default_permissions
 			}
 		));
 

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -32,19 +32,16 @@ fn asset_options(initial_issuance: u64, permissions: PermissionLatest<u64>) -> A
 fn issuing_asset_units_to_issuer_should_work() {
 	let next_asset_id = 1000;
 	let asset_id = 16000;
-	let balance = 100;
-	let account = 1;
-
-	ExtBuilder::default().free_balance((asset_id, account, balance)).build().execute_with(|| {
-		let permissions = PermissionLatest::new(account);
+	ExtBuilder::default().free_balance((asset_id, 1, 100)).build().execute_with(|| {
+		let permissions = PermissionLatest::new(1);
 
 		assert_eq!(GenericAsset::next_asset_id(), next_asset_id);
-		assert_ok!(GenericAsset::create(Origin::ROOT, account, asset_options(balance, permissions)));
+		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(100, permissions)));
 		assert_eq!(GenericAsset::next_asset_id(), next_asset_id + 1);
 
-		assert_eq!(GenericAsset::total_issuance(&next_asset_id), balance);
-		assert_eq!(GenericAsset::free_balance(&next_asset_id, &account), balance);
-		assert_eq!(GenericAsset::free_balance(&asset_id, &account), balance);
+		assert_eq!(GenericAsset::total_issuance(&next_asset_id), 100);
+		assert_eq!(GenericAsset::free_balance(&next_asset_id, &1), 100);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
 	});
 }
 
@@ -65,7 +62,6 @@ fn issuing_with_next_asset_id_overflow_should_not_work() {
 #[test]
 fn querying_total_supply_should_work() {
 	let asset_id = 1000;
-
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
 
@@ -108,12 +104,11 @@ fn querying_total_supply_should_work() {
 #[test]
 fn transferring_amount_should_work() {
 	let asset_id = 1000;
-	let balance = 100;
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
 
-		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(balance, permissions)));
-		assert_eq!(GenericAsset::free_balance(&asset_id, &1), balance);
+		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(100, permissions)));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
 		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 2, 40));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 60);
 		assert_eq!(GenericAsset::free_balance(&asset_id, &2), 40);
@@ -152,7 +147,6 @@ fn transferring_amount_should_fail_when_transferring_more_than_free_balance() {
 #[test]
 fn transferring_less_than_one_unit_should_not_work() {
 	let asset_id = 1000;
-
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
 
@@ -177,15 +171,13 @@ fn transferring_less_than_one_unit_should_not_work() {
 #[test]
 fn self_transfer_should_unchanged() {
 	let asset_id = 1000;
-	let balance = 100;
-
 	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
 
-		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(balance, permissions)));
-		assert_eq!(GenericAsset::free_balance(&asset_id, &1), balance);
+		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(100, permissions)));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
 		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 1, 10));
-		assert_eq!(GenericAsset::free_balance(&asset_id, &1), balance);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
 	});
 }
 
@@ -241,17 +233,15 @@ fn total_balance_should_be_zero() {
 #[test]
 fn total_balance_should_be_equal_to_account_balance() {
 	let asset_id = 1000;
-	let account = 1;
-	let balance = 100;
-	ExtBuilder::default().free_balance((16000, account, 100000)).build().execute_with(|| {
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
  
-		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(balance, permissions)));
-	  assert_eq!(GenericAsset::free_balance(&asset_id, &account), balance);
-		assert_ok!(GenericAsset::reserve(&asset_id, &account, balance / 2));
-		assert_eq!(GenericAsset::reserved_balance(&asset_id, &account), balance / 2);
-		assert_eq!(GenericAsset::free_balance(&asset_id, &account), balance / 2);
-		assert_eq!(GenericAsset::total_balance(&asset_id, &account), balance);
+		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(100, permissions)));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
+		assert_ok!(GenericAsset::reserve(&asset_id, &1, 40));
+		assert_eq!(GenericAsset::reserved_balance(&asset_id, &1), 40);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 60);
+		assert_eq!(GenericAsset::total_balance(&asset_id, &1), 100);
 	});
 }
 
@@ -532,32 +522,23 @@ fn repatriate_reserved_return_none() {
 // - Should create a new reserved asset.
 #[test]
 fn create_reserved_should_create_a_default_account_with_the_balance_given() {
-	let amount = 500;
 	let asset_id = 9;
-	let account = 0;
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
-		let options = asset_options(amount, permissions);
+		let options = asset_options(100, permissions);
 
-		assert_ok!(GenericAsset::create(Origin::ROOT, 1, options.clone()));
 		assert_ok!(GenericAsset::create_reserved(Origin::ROOT, asset_id, options));
-		// Tests for side effects.
-		assert_eq!(<TotalIssuance<Test>>::get(asset_id), amount);
-		assert_eq!(
-			<FreeBalance<Test>>::get(&asset_id, &account),
-			amount
-		);
+		assert_eq!(<TotalIssuance<Test>>::get(asset_id), 100);
+		assert_eq!(<FreeBalance<Test>>::get(&asset_id, &0), 100);
 	});
 }
 
 #[test]
 fn create_reserved_with_non_reserved_asset_id_should_failed() {
-	let amount = 500;
-	let account = 0;
-	let asset_id = 11;
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
-		let options = asset_options(amount, permissions);
+		let options = asset_options(100, permissions);
+		let asset_id = 11;
 
 		// create reserved asset with asset_id >= next_asset_id should fail
 		assert_noop!(
@@ -569,18 +550,16 @@ fn create_reserved_with_non_reserved_asset_id_should_failed() {
 
 #[test]
 fn create_reserved_with_a_taken_asset_id_should_failed() {
-	let amount = 500;
-	let account = 0;
-	let asset_id = 9;
 	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let permissions = PermissionLatest::new(1);
-		let options = asset_options(amount, permissions);
+		let options = asset_options(100, permissions);
+		let asset_id = 9;
 		
 		// create reserved asset with asset_id < next_asset_id should success
 		assert_ok!(GenericAsset::create_reserved(Origin::ROOT, asset_id, options.clone()));
-		assert_eq!(<TotalIssuance<Test>>::get(asset_id), amount);
+		assert_eq!(<TotalIssuance<Test>>::get(asset_id), 100);
 		// all reserved assets belong to account: 0 which is the default value of `AccountId`
-		assert_eq!(<FreeBalance<Test>>::get(&asset_id, &account), amount);
+		assert_eq!(<FreeBalance<Test>>::get(&asset_id, &0), 100);
 		// create reserved asset with existing asset_id: 9 should fail
 		assert_noop!(
 			GenericAsset::create_reserved(Origin::ROOT, asset_id, options.clone()),
@@ -597,15 +576,10 @@ fn create_reserved_with_a_taken_asset_id_should_failed() {
 // Then
 // - Should throw a permission error
 #[test]
-fn mint_should_throw_permission_error() {
+fn mint_without_permission_should_throw_error() {
 	ExtBuilder::default().build().execute_with(|| {
-		let origin = 1;
-		let asset_id = 4;
-		let to_account = 2;
-		let amount = 100;
-
 		assert_noop!(
-			GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount),
+			GenericAsset::mint(Origin::signed(1), 9, 2, 100),
 			Error::<Test>::NoMintPermission,
 		);
 	});
@@ -634,7 +608,7 @@ fn mint_should_increase_asset() {
 		assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), amount);
 		// Origin's free_balance should not change.
 		assert_eq!(GenericAsset::free_balance(&asset_id, &origin), initial_issuance);
-		assert_eq!(GenericAsset::total_issuance(asset_id),initial_issuance + amount);
+		assert_eq!(GenericAsset::total_issuance(asset_id), initial_issuance + amount);
 	});
 }
 
@@ -681,7 +655,7 @@ fn burn_should_burn_an_asset() {
 
 		assert_ok!(GenericAsset::create(Origin::ROOT, 1, asset_options(initial_issuance, permissions)));
 		assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
-		assert_eq!(GenericAsset::total_issuance(asset_id),initial_issuance + amount);
+		assert_eq!(GenericAsset::total_issuance(asset_id), initial_issuance + amount);
 
 		assert_ok!(GenericAsset::burn(
 			Origin::signed(origin),
@@ -690,7 +664,7 @@ fn burn_should_burn_an_asset() {
 			burn_amount
 		));
 		assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), amount - burn_amount);
-		assert_eq!(GenericAsset::total_issuance(asset_id),initial_issuance + amount - burn_amount);
+		assert_eq!(GenericAsset::total_issuance(asset_id), initial_issuance + amount - burn_amount);
 	});
 }
 


### PR DESCRIPTION
This PR addressed all the test part in GA audit.

## Changes

- Check `total_issuance` in related tests.
- Rename `staking_asset_id_should_return_0` and `spending_asset_id_should_return_10`
- Fix `issuing_asset_units_to_issuer_should_work `
- Fix `total_balance_should_be_equal_to_account_balance`
- Add `free_balance` and `reserved_balance` check in all slash related tests
- Add test `create_reserved_with_invalid_asset_id_should_failed`

## Refactor

- Add constant value  to replace  all the magic numbers
- Add `asset_options` function to config `AssetOptions`
- To make a consistent, all `failed test` using `should_fail` other than `not_work` 