### PR TITLE
Exposed doughnut module error_codes 

### DIFF
--- a/frame/executive/tests/doughnut_integration.rs
+++ b/frame/executive/tests/doughnut_integration.rs
@@ -338,8 +338,14 @@ fn delegated_dispatch_fails_when_extrinsic_signer_is_not_doughnut_holder() {
 			Digest::default(),
 		));
 
+		let expected_error = TransactionValidityError::Invalid(
+			InvalidTransaction::Custom(
+				prml_doughnut::constants::error_code::VALIDATION_HOLDER_SIGNER_IDENTITY_MISMATCH
+			)
+		);
+
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(180))));
+		assert_eq!(r, Err(expected_error));
 	});
 }
 
@@ -383,8 +389,12 @@ fn delegated_dispatch_fails_when_doughnut_is_expired() {
 			Digest::default(),
 		));
 
+		let expected_error = TransactionValidityError::Invalid(
+			InvalidTransaction::Custom(prml_doughnut::constants::error_code::VALIDATION_EXPIRED)
+		);
+
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(181))));
+		assert_eq!(r, Err(expected_error));
 	});
 }
 
@@ -426,8 +436,13 @@ fn delegated_dispatch_fails_when_doughnut_is_premature() {
 			[69u8; 32].into(),
 			Digest::default(),
 		));
+
+		let expected_error = TransactionValidityError::Invalid(
+			InvalidTransaction::Custom(prml_doughnut::constants::error_code::VALIDATION_PREMATURE)
+		);
+
 		let r = Executive::apply_extrinsic(uxt);
-		assert_eq!(r, Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(182))));
+		assert_eq!(r, Err(expected_error));
 	});
 }
 

--- a/prml/doughnut/src/constants.rs
+++ b/prml/doughnut/src/constants.rs
@@ -16,7 +16,7 @@
 
 //! Plug Doughnut Constants
 
-pub (crate) mod error_code {
+pub mod error_code {
 	//! Plug Doughnut Error Code Constants
 	pub const VERIFY_INVALID: u8 = 170;
 	pub const VERIFY_UNSUPPORTED_VERSION: u8 = 171;

--- a/prml/doughnut/src/lib.rs
+++ b/prml/doughnut/src/lib.rs
@@ -27,7 +27,8 @@ use frame_support::Parameter;
 use frame_support::additional_traits::DelegatedDispatchVerifier;
 use frame_support::traits::Time;
 
-pub mod constants;
+mod constants;
+pub use constants::error_code;
 mod impls;
 
 // TODO: This should eventually become a super trait for `system::Trait` so that all doughnut functionality may be moved here

--- a/prml/doughnut/src/lib.rs
+++ b/prml/doughnut/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::Parameter;
 use frame_support::additional_traits::DelegatedDispatchVerifier;
 use frame_support::traits::Time;
 
-mod constants;
+pub mod constants;
 mod impls;
 
 // TODO: This should eventually become a super trait for `system::Trait` so that all doughnut functionality may be moved here


### PR DESCRIPTION
Expose doughnut runtime module's `error_code` module so that they can be checked in integration tests.

This is especially useful in cennznet integration tests so that we don't use fragile magic numbers (like `180`) to describe verifcation/validation failure cases.

## Changes:

- `prml_doughnut/constants.rs` `error_code` made `pub`
- `prml_doughnut/lib.rs` exposes `pub mod constants;`
- `frame_executive/doughnut_integration.rs` magic numbers in error codes replaced by references to `prml_doughnut::constants::error_code`

## Concerns:

* None