### PR TITLE
Fix CI by explicitly setting nightly version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,10 @@ commands:
             fi
             source ~/.cargo/env
             rustup install $RUST_VERSION
-            rustup default stable
-            rustup install nightly
-            rustup target add wasm32-unknown-unknown --toolchain=nightly
+            rustup default $RUST_VERSION
+            rustup install nightly-2020-04-17
+            rustup target add wasm32-unknown-unknown --toolchain=nightly-2020-04-17
+            rustup target add x86_64-unknown-linux-musl --toolchain=$RUST_VERSION
             export RUSTC_WRAPPER="" # sccache is uninstalled at this point so it must be unset here for `wasm-gc` install
             command -v wasm-gc || cargo install --git https://github.com/alexcrichton/wasm-gc --force
             rustc --version; cargo --version; rustup --version


### PR DESCRIPTION
This PR fixes CI so it passes.
Current CI is failing because some packages aren't supported on the varying nightly builds being used.

## Changes
* Explicitly set a nightly build version

## Concerns
* Parity's rust-builder image didn't work for this CI. It would be nice to create our own docker `plug/rust-builder` image that we can use for CI across all plug chains.
