### PR TITLE
Add a "rpc-disable-reserved-peers" feature flag to sc-rpc

### DIFF
--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -14,4 +14,4 @@ hyper = "0.12.35"
 jsonrpc-core-client = { version = "14.0.3", features = ["http", "ws"] }
 log = "0.4.8"
 node-primitives = { version = "2.0.0-alpha.5", path = "../primitives" }
-sc-rpc = { version = "2.0.0-alpha.5", path = "../../../client/rpc" }
+sc-rpc = { version = "2.0.0-alpha.5", path = "../../../client/rpc", default-features = false }

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -25,3 +25,8 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
 sp-rpc = { version = "2.0.0-alpha.5", path = "../../primitives/rpc" }
+
+[features]
+modify-reserved-peers = []
+
+default = ["modify-reserved-peers"]

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -25,8 +25,3 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
 sp-rpc = { version = "2.0.0-alpha.5", path = "../../primitives/rpc" }
-
-[features]
-rpc-config-reserved-peers = []
-
-default = []

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -20,13 +20,13 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core" }
 sp-version = { version = "2.0.0-alpha.5", path = "../../primitives/version" }
-sp-runtime = { path = "../../primitives/runtime" , version = "2.0.0-alpha.5"}
+sp-runtime = { path = "../../primitives/runtime", version = "2.0.0-alpha.5"}
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
 sp-rpc = { version = "2.0.0-alpha.5", path = "../../primitives/rpc" }
 
 [features]
-modify-reserved-peers = []
+rpc-config-reserved-peers = []
 
-default = ["modify-reserved-peers"]
+default = []

--- a/client/rpc-api/src/system/error.rs
+++ b/client/rpc-api/src/system/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
 	NotHealthy(Health),
 	/// Peer argument is malformatted.
 	MalformattedPeerArg(String),
+	/// Reserved Peer Commands Disabled
+	ReservedPeerCommandsDisabled,
 }
 
 impl std::error::Error for Error {}
@@ -48,6 +50,11 @@ impl From<Error> for rpc::Error {
 			Error::MalformattedPeerArg(ref e) => rpc::Error {
 				code :rpc::ErrorCode::ServerError(BASE_ERROR + 2),
 				message: e.clone(),
+				data: None,
+			},
+			Error::ReservedPeerCommandsDisabled => rpc::Error {
+				code :rpc::ErrorCode::ServerError(BASE_ERROR + 3),
+				message: "Reserved Peer Commands Disabled".to_string(),
 				data: None,
 			}
 		}

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -71,15 +71,13 @@ pub trait SystemApi<Hash, Number> {
 	///
 	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
 	/// is an example of a valid, passing multiaddr with PeerId attached.
-	#[cfg(feature = "modify-reserved-peers")]
-	#[rpc(name = "system_addReservedPeer", returns = "()")]
+	#[cfg_attr(feature = "rpc-config-reserved-peers", rpc(name = "system_addReservedPeer", returns = "()"))]
 	fn system_add_reserved_peer(&self, peer: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 
 	/// Remove a reserved peer. Returns the empty string or an error. The string
 	/// should encode only the PeerId e.g. `QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`.
-	#[cfg(feature = "modify-reserved-peers")]
-	#[rpc(name = "system_removeReservedPeer", returns = "()")]
+	#[cfg_attr(feature = "rpc-config-reserved-peers", rpc(name = "system_removeReservedPeer", returns = "()"))]
 	fn system_remove_reserved_peer(&self, peer_id: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -71,13 +71,13 @@ pub trait SystemApi<Hash, Number> {
 	///
 	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
 	/// is an example of a valid, passing multiaddr with PeerId attached.
-	#[cfg_attr(feature = "rpc-config-reserved-peers", rpc(name = "system_addReservedPeer", returns = "()"))]
+	#[rpc(name = "system_addReservedPeer", returns = "()")]
 	fn system_add_reserved_peer(&self, peer: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 
 	/// Remove a reserved peer. Returns the empty string or an error. The string
 	/// should encode only the PeerId e.g. `QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`.
-	#[cfg_attr(feature = "rpc-config-reserved-peers", rpc(name = "system_removeReservedPeer", returns = "()"))]
+	#[rpc(name = "system_removeReservedPeer", returns = "()")]
 	fn system_remove_reserved_peer(&self, peer_id: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -71,12 +71,14 @@ pub trait SystemApi<Hash, Number> {
 	///
 	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
 	/// is an example of a valid, passing multiaddr with PeerId attached.
+	#[cfg(feature = "modify-reserved-peers")]
 	#[rpc(name = "system_addReservedPeer", returns = "()")]
 	fn system_add_reserved_peer(&self, peer: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 
 	/// Remove a reserved peer. Returns the empty string or an error. The string
 	/// should encode only the PeerId e.g. `QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`.
+	#[cfg(feature = "modify-reserved-peers")]
 	#[rpc(name = "system_removeReservedPeer", returns = "()")]
 	fn system_remove_reserved_peer(&self, peer_id: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Substrate Client RPC"
 
 [features]
+# Disables system_addReservedPeer and system_removeReservedPeer rpc methods
 rpc-disable-reserved-peers = []
 default = []
 

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -9,9 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Substrate Client RPC"
 
 [features]
-rpc-config-reserved-peers = ["sc-rpc-api/rpc-config-reserved-peers"]
-
-default = ["rpc-config-reserved-peers"]
+rpc-disable-reserved-peers = []
+default = []
 
 [dependencies]
 sc-rpc-api = { version = "0.8.0-alpha.5", path = "../rpc-api" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -8,6 +8,11 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate Client RPC"
 
+[features]
+rpc-config-reserved-peers = ["sc-rpc-api/rpc-config-reserved-peers"]
+
+default = ["rpc-config-reserved-peers"]
+
 [dependencies]
 sc-rpc-api = { version = "0.8.0-alpha.5", path = "../rpc-api" }
 sc-client-api = { version = "2.0.0-alpha.5", path = "../api" }
@@ -42,3 +47,4 @@ sp-io = { version = "2.0.0-alpha.5", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"
 sc-transaction-pool = { version = "2.0.0-alpha.5", path = "../transaction-pool" }
+


### PR DESCRIPTION
This PR allows us to optionally disable reserved peer client rpc calls.

It adds the feature flag `rpc-disable-reserved-peers` to the sc-rpc, which is not set by default.

When `rpc-disable-reserved-peers` is not set, then the rpc call behaves as normal:
```
hoani@Hoani-MBP plug-blockchain % curl -H "Content-Type: application/json" --data '{"id": 1,"jsonrpc": "2.0","method": "system_addReservedPeer","params": ["ws://hoani-node.node"]}' localhost:9933
{"jsonrpc":"2.0","error":{"code":2002,"message":"MultiaddrParse(InvalidMultiaddr)"},"id":1}
```

When `rpc-disable-reserved-peers` is set like this (in `bin/node/cli/Cargo.toml`):
```
sc-rpc = { version = "2.0.0-alpha.5", path = "../../../client/rpc", features=["rpc-disable-reserved-peers"] }
```

Then the RPC call is rejected:
```
hoani@Hoani-MBP plug-blockchain % curl -H "Content-Type: application/json" --data '{"id": 1,"jsonrpc": "2.0","method": "system_addReservedPeer","params": ["ws://hoani-node.node"]}' localhost:9933
{"jsonrpc":"2.0","error":{"code":2003,"message":"Reserved Peer Commands Disabled"},"id":1}
```

## Changes
* Add feature flag `rpc-disable-reserved-peers` to `sc-rpc`
* Add error type `Error::ReservedPeerCommandsDisabled` to `sc_rpc_api::system::error`
* Add feature check to disable the `removed_reserved_peer` and `add_reserved_peer` calls

## Concerns
* I would have preferred to completely disable the rpc calls based on feature flags, but given that the `#[rpc]` attributes were being processed before the `#[cfg_attr...]`, this wouldn't work.

