### PR TITLE
Transaction pool fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
     steps:
       - run:
           name: Build
-          command:
+          command: |
             cargo --version
             cargo check
           no_output_timeout: 30m
@@ -76,7 +76,7 @@ jobs:
     resource_class: large
     environment:
       BASH_ENV: ~/.cargo/env
-      RUST_VERSION: 1.42.0
+      RUST_VERSION: 1.43.1
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
     steps:
@@ -92,7 +92,7 @@ jobs:
     resource_class: large
     environment:
       BASH_ENV: ~/.cargo/env
-      RUST_VERSION: 1.42.0
+      RUST_VERSION: 1.43.1
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 10G
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 
 [[package]]
+name = "intervalier"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
+dependencies = [
+ "futures 0.3.4",
+ "futures-timer 2.0.2",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,9 +4813,9 @@ checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e42755f26e5ea21a6a819d9e63cbd70713e9867a2b767ec2cc65ca7659532c5"
+checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
 dependencies = [
  "cfg-if",
  "ethereum-types",
@@ -5173,6 +5183,20 @@ dependencies = [
  "protobuf",
  "quick-error",
  "spin",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "protobuf",
+ "spin",
+ "thiserror",
 ]
 
 [[package]]
@@ -5954,6 +5978,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
+ "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
@@ -5990,6 +6015,7 @@ dependencies = [
  "sp-test-primitives",
  "sp-transaction-pool",
  "sp-trie",
+ "sp-utils",
  "sp-version",
 ]
 
@@ -6350,6 +6376,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
+ "sp-utils",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
@@ -6562,6 +6589,7 @@ dependencies = [
  "sp-session",
  "sp-state-machine",
  "sp-transaction-pool",
+ "sp-utils",
  "sp-version",
  "substrate-test-runtime-client",
  "tokio 0.1.22",
@@ -6660,6 +6688,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
+ "sp-utils",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "sysinfo",
@@ -6740,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc3"
 dependencies = [
  "assert_matches",
  "criterion 0.3.1",
@@ -6756,32 +6785,38 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-transaction-pool",
+ "sp-utils",
  "substrate-test-runtime",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc3"
 dependencies = [
  "assert_matches",
  "derive_more",
  "futures 0.3.4",
  "futures-diagnose",
- "futures-timer 2.0.2",
  "hex",
+ "intervalier",
  "log 0.4.8",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.0",
+ "sc-block-builder",
  "sc-client-api",
  "sc-transaction-graph",
  "sp-api",
  "sp-blockchain",
+ "sp-consensus",
  "sp-core",
  "sp-keyring",
  "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
+ "sp-utils",
+ "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "substrate-test-runtime-transaction-pool",
  "wasm-timer",
@@ -7712,8 +7747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tracing"
+version = "2.0.0-rc3"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc2"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -7721,7 +7763,9 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-api",
+ "sp-blockchain",
  "sp-runtime",
+ "sp-utils",
 ]
 
 [[package]]
@@ -7740,6 +7784,16 @@ dependencies = [
  "trie-db",
  "trie-root",
  "trie-standardmap",
+]
+
+[[package]]
+name = "sp-utils"
+version = "2.0.0-rc3"
+dependencies = [
+ "futures 0.3.4",
+ "futures-core",
+ "lazy_static",
+ "prometheus 0.8.0",
 ]
 
 [[package]]
@@ -7986,7 +8040,7 @@ dependencies = [
  "futures-util",
  "hyper 0.13.3",
  "log 0.4.8",
- "prometheus",
+ "prometheus 0.7.0",
  "tokio 0.2.13",
 ]
 
@@ -8222,9 +8276,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.12.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccb41798287e8e299a701b5560d886d6ca2c3e7115e9ea2cb68c123aec339b7"
+checksum = "1cac193374347e7c263c5f547524f36ff8ec6702d56c8799c8331d26dffe8c1e"
 dependencies = [
  "cfg-if",
  "doc-comment",
@@ -8818,7 +8872,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,6 +34,7 @@ sp-blockchain = { version = "2.0.0-alpha.5", path = "../primitives/blockchain" }
 sp-state-machine = { version = "0.8.0-alpha.5", path = "../primitives/state-machine" }
 sc-telemetry = { version = "2.0.0-alpha.5", path = "telemetry" }
 sp-trie = { version = "2.0.0-alpha.5", path = "../primitives/trie" }
+sp-utils = { version = "2.0.0-rc3", path = "../primitives/utils" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-alpha.5", path = "../utils/prometheus" }
 tracing = "0.1.10"
 

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -36,6 +36,7 @@ sc-telemetry = { version = "2.0.0-alpha.5", path = "../telemetry" }
 sp-trie = { version = "2.0.0-alpha.5", path = "../../primitives/trie" }
 sp-storage = { version = "2.0.0-alpha.5", path = "../../primitives/storage" }
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
+sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 
 [dev-dependencies]
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -65,8 +65,10 @@ pub struct ImportSummary<Block: BlockT> {
 	pub is_new_best: bool,
 	/// Optional storage changes.
 	pub storage_changes: Option<(StorageCollection, ChildStorageCollection)>,
-	/// Blocks that got retracted because of this one got imported.
-	pub retracted: Vec<Block::Hash>,
+	/// Tree route from old best to new best.
+	///
+	/// If `None`, there was no re-org while importing.
+	pub tree_route: Option<sp_blockchain::TreeRoute<Block>>,
 }
 
 /// Import operation wrapper

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -333,12 +333,12 @@ mod tests {
 		}.into_signed_tx()
 	}
 
-	fn chain_event<B: BlockT>(block_number: u64, header: B::Header) -> ChainEvent<B>
+	fn chain_event<B: BlockT>(header: B::Header) -> ChainEvent<B>
 		where NumberFor<B>: From<u64>
 	{
 		ChainEvent::NewBlock {
-			id: BlockId::Number(block_number.into()),
-			retracted: vec![],
+			hash: header.hash(),
+			tree_route: None,
 			is_new_best: true,
 			header,
 		}
@@ -349,7 +349,11 @@ mod tests {
 		// given
 		let client = Arc::new(substrate_test_runtime_client::new());
 		let txpool = Arc::new(
-			BasicPool::new(Default::default(), Arc::new(FullChainApi::new(client.clone()))).0
+			BasicPool::new(
+				Default::default(),
+				Arc::new(FullChainApi::new(client.clone())),
+				None,
+			).0
 		);
 
 		futures::executor::block_on(
@@ -358,7 +362,6 @@ mod tests {
 
 		futures::executor::block_on(
 			txpool.maintain(chain_event(
-				0,
 				client.header(&BlockId::Number(0u64)).expect("header get error").expect("there should be header")
 			))
 		);
@@ -397,7 +400,11 @@ mod tests {
 	fn should_not_panic_when_deadline_is_reached() {
 		let client = Arc::new(substrate_test_runtime_client::new());
 		let txpool = Arc::new(
-			BasicPool::new(Default::default(), Arc::new(FullChainApi::new(client.clone()))).0
+			BasicPool::new(
+				Default::default(),
+				Arc::new(FullChainApi::new(client.clone())),
+				None,
+			).0
 		);
 
 		let mut proposer_factory = ProposerFactory::new(client.clone(), txpool.clone());
@@ -429,7 +436,11 @@ mod tests {
 			.build_with_backend();
 		let client = Arc::new(client);
 		let txpool = Arc::new(
-			BasicPool::new(Default::default(), Arc::new(FullChainApi::new(client.clone()))).0
+			BasicPool::new(
+				Default::default(),
+				Arc::new(FullChainApi::new(client.clone())),
+				None,
+			).0
 		);
 		let genesis_hash = client.info().best_hash;
 		let block_id = BlockId::Hash(genesis_hash);
@@ -440,7 +451,6 @@ mod tests {
 
 		futures::executor::block_on(
 			txpool.maintain(chain_event(
-				0,
 				client.header(&BlockId::Number(0u64)).expect("header get error").expect("there should be header")
 			))
 		);
@@ -482,7 +492,11 @@ mod tests {
 		// given
 		let mut client = Arc::new(substrate_test_runtime_client::new());
 		let txpool = Arc::new(
-			BasicPool::new(Default::default(), Arc::new(FullChainApi::new(client.clone()))).0
+			BasicPool::new(
+				Default::default(),
+				Arc::new(FullChainApi::new(client.clone())),
+				None,
+			).0
 		);
 
 		futures::executor::block_on(
@@ -535,7 +549,6 @@ mod tests {
 
 		futures::executor::block_on(
 			txpool.maintain(chain_event(
-				0,
 				client.header(&BlockId::Number(0u64)).expect("header get error").expect("there should be header")
 			))
 		);
@@ -546,7 +559,6 @@ mod tests {
 
 		futures::executor::block_on(
 			txpool.maintain(chain_event(
-				1,
 				client.header(&BlockId::Number(1)).expect("header get error").expect("there should be header")
 			))
 		);

--- a/client/consensus/manual-seal/src/seal_new_block.rs
+++ b/client/consensus/manual-seal/src/seal_new_block.rs
@@ -88,7 +88,7 @@ pub async fn seal_new_block<B, SC, CB, E, T, P>(
 		E: Environment<B>,
 		<E as Environment<B>>::Error: std::fmt::Display,
 		<E::Proposer as Proposer<B>>::Error: std::fmt::Display,
-		P: txpool::ChainApi<Block=B, Hash=<B as BlockT>::Hash>,
+		P: txpool::ChainApi<Block=B>,
 		SC: SelectChain<B>,
 {
 	let future = async {

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -39,6 +39,7 @@ prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../..
 sc-block-builder = { version = "0.8.0-alpha.5", path = "../block-builder" }
 finality-grandpa = { version = "0.11.2", features = ["derive-codec"] }
 pin-project = "0.4.6"
+sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 
 [dev-dependencies]
 finality-grandpa = { version = "0.11.2", features = ["derive-codec", "test-helpers"] }

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -18,7 +18,6 @@ use std::{sync::Arc, collections::HashMap};
 
 use log::{debug, trace, info};
 use parity_scale_codec::Encode;
-use futures::channel::mpsc;
 use parking_lot::RwLockWriteGuard;
 
 use sp_blockchain::{BlockStatus, well_known_cache_keys};
@@ -36,6 +35,7 @@ use sp_runtime::generic::{BlockId, OpaqueDigestItemId};
 use sp_runtime::traits::{
 	Block as BlockT, DigestFor, Header as HeaderT, NumberFor, Zero,
 };
+use sp_utils::mpsc::TracingUnboundedSender;
 
 use crate::{Error, CommandOrError, NewAuthoritySet, VoterCommand};
 use crate::authorities::{AuthoritySet, SharedAuthoritySet, DelayKind, PendingChange};
@@ -57,7 +57,7 @@ pub struct GrandpaBlockImport<Backend, Block: BlockT, Client, SC> {
 	inner: Arc<Client>,
 	select_chain: SC,
 	authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
-	send_voter_commands: mpsc::UnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
+	send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
 	authority_set_hard_forks: HashMap<Block::Hash, PendingChange<Block::Hash, NumberFor<Block>>>,
 	_phantom: PhantomData<Backend>,
@@ -536,7 +536,7 @@ impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Clie
 		inner: Arc<Client>,
 		select_chain: SC,
 		authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
-		send_voter_commands: mpsc::UnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
+		send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 		consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
 		authority_set_hard_forks: Vec<(SetId, PendingChange<Block::Hash, NumberFor<Block>>)>,
 	) -> GrandpaBlockImport<Backend, Block, Client, SC> {

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -55,7 +55,6 @@
 use futures::prelude::*;
 use futures::StreamExt;
 use log::{debug, info};
-use futures::channel::mpsc;
 use sc_client_api::{
 	backend::{AuxStore, Backend},
 	LockImportRun, BlockchainEvents, CallExecutor,
@@ -71,6 +70,7 @@ use sp_consensus::{SelectChain, BlockImport};
 use sp_core::Pair;
 use sc_telemetry::{telemetry, CONSENSUS_INFO, CONSENSUS_DEBUG};
 use serde_json;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
 
 use sp_finality_tracker;
 
@@ -378,7 +378,7 @@ pub struct LinkHalf<Block: BlockT, C, SC> {
 	client: Arc<C>,
 	select_chain: SC,
 	persistent_data: PersistentData<Block>,
-	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
+	voter_commands_rx: TracingUnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
 }
 
 /// Provider for the Grandpa authority set configured on the genesis block.
@@ -475,7 +475,7 @@ where
 		}
 	)?;
 
-	let (voter_commands_tx, voter_commands_rx) = mpsc::unbounded();
+	let (voter_commands_tx, voter_commands_rx) = tracing_unbounded("mpsc_grandpa_voter_command");
 
 	// create pending change objects with 0 delay and enacted on finality
 	// (i.e. standard changes) for each authority set hard fork.
@@ -595,7 +595,7 @@ pub struct GrandpaParams<Block: BlockT, C, N, SC, VR> {
 	/// The inherent data providers.
 	pub inherent_data_providers: InherentDataProviders,
 	/// If supplied, can be used to hook on telemetry connection established events.
-	pub telemetry_on_connect: Option<futures::channel::mpsc::UnboundedReceiver<()>>,
+	pub telemetry_on_connect: Option<TracingUnboundedReceiver<()>>,
 	/// A voting rule used to potentially restrict target votes.
 	pub voting_rule: VR,
 	/// The prometheus metrics registry.
@@ -701,7 +701,7 @@ pub fn run_grandpa_voter<Block: BlockT, BE: 'static, C, N, SC, VR>(
 struct VoterWork<B, Block: BlockT, C, N: NetworkT<Block>, SC, VR> {
 	voter: Pin<Box<dyn Future<Output = Result<(), CommandOrError<Block::Hash, NumberFor<Block>>>> + Send>>,
 	env: Arc<Environment<B, Block, C, N, SC, VR>>,
-	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
+	voter_commands_rx: TracingUnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	network: NetworkBridge<Block, N>,
 }
 
@@ -722,7 +722,7 @@ where
 		select_chain: SC,
 		voting_rule: VR,
 		persistent_data: PersistentData<Block>,
-		voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
+		voter_commands_rx: TracingUnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
 		prometheus_registry: Option<prometheus_endpoint::Registry>,
 	) -> Self {
 

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -18,7 +18,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::{prelude::*, channel::mpsc};
+use futures::prelude::*;
 
 use finality_grandpa::{
 	BlockNumberOps, Error as GrandpaError, voter, voter_set::VoterSet
@@ -27,6 +27,7 @@ use log::{debug, info, warn};
 
 use sp_consensus::SelectChain;
 use sc_client_api::backend::Backend;
+use sp_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::traits::{NumberFor, Block as BlockT};
 use sp_blockchain::HeaderMetadata;
 use crate::{
@@ -206,7 +207,7 @@ struct ObserverWork<B: BlockT, BE, Client, N: NetworkT<B>> {
 	network: NetworkBridge<B, N>,
 	persistent_data: PersistentData<B>,
 	keystore: Option<sc_keystore::KeyStorePtr>,
-	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,
+	voter_commands_rx: TracingUnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,
 	_phantom: PhantomData<BE>,
 }
 
@@ -223,7 +224,7 @@ where
 		network: NetworkBridge<B, Network>,
 		persistent_data: PersistentData<B>,
 		keystore: Option<sc_keystore::KeyStorePtr>,
-		voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,
+		voter_commands_rx: TracingUnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,
 	) -> Self {
 
 		let mut work = ObserverWork {
@@ -375,6 +376,7 @@ mod tests {
 	use super::*;
 
 	use assert_matches::assert_matches;
+	use sp_utils::mpsc::tracing_unbounded;
 	use crate::{aux_schema,	communication::tests::{Event, make_test_network}};
 	use substrate_test_runtime_client::{TestClientBuilder, TestClientBuilderExt};
 	use sc_network::PeerId;
@@ -411,7 +413,7 @@ mod tests {
 			|| Ok(vec![]),
 		).unwrap();
 
-		let (_tx, voter_command_rx) = mpsc::unbounded();
+		let (_tx, voter_command_rx) = tracing_unbounded("");
 		let observer = ObserverWork::new(
 			client,
 			tester.net_handle.clone(),

--- a/client/finality-grandpa/src/until_imported.rs
+++ b/client/finality-grandpa/src/until_imported.rs
@@ -33,10 +33,10 @@ use sc_client_api::{BlockImportNotification, ImportNotifications};
 use futures::prelude::*;
 use futures::stream::Fuse;
 use futures_timer::Delay;
-use futures::channel::mpsc::UnboundedReceiver;
 use finality_grandpa::voter;
 use parking_lot::Mutex;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_utils::mpsc::TracingUnboundedReceiver;
 
 use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
@@ -80,7 +80,7 @@ pub(crate) enum DiscardWaitOrReady<Block: BlockT, W, R> {
 /// Buffering imported messages until blocks with given hashes are imported.
 #[pin_project::pin_project]
 pub(crate) struct UntilImported<Block: BlockT, BlockStatus, BlockSyncRequester, I, M: BlockUntilImported<Block>> {
-	import_notifications: Fuse<UnboundedReceiver<BlockImportNotification<Block>>>,
+	import_notifications: Fuse<TracingUnboundedReceiver<BlockImportNotification<Block>>>,
 	block_sync_requester: BlockSyncRequester,
 	status_check: BlockStatus,
 	#[pin]
@@ -467,18 +467,18 @@ mod tests {
 	use sc_client_api::BlockImportNotification;
 	use futures::future::Either;
 	use futures_timer::Delay;
-	use futures::channel::mpsc;
+	use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 	use finality_grandpa::Precommit;
 
 	#[derive(Clone)]
 	struct TestChainState {
-		sender: mpsc::UnboundedSender<BlockImportNotification<Block>>,
+		sender: TracingUnboundedSender<BlockImportNotification<Block>>,
 		known_blocks: Arc<Mutex<HashMap<Hash, u64>>>,
 	}
 
 	impl TestChainState {
 		fn new() -> (Self, ImportNotifications<Block>) {
-			let (tx, rx) = mpsc::unbounded();
+			let (tx, rx) = tracing_unbounded("test");
 			let state = TestChainState {
 				sender: tx,
 				known_blocks: Arc::new(Mutex::new(HashMap::new())),
@@ -501,7 +501,7 @@ mod tests {
 				origin: BlockOrigin::File,
 				header,
 				is_new_best: false,
-				retracted: vec![],
+				tree_route: None,
 			}).unwrap();
 		}
 	}
@@ -575,7 +575,7 @@ mod tests {
 		// enact all dependencies before importing the message
 		enact_dependencies(&chain_state);
 
-		let (global_tx, global_rx) = futures::channel::mpsc::unbounded();
+		let (global_tx, global_rx) = tracing_unbounded("test");
 
 		let until_imported = UntilGlobalMessageBlocksImported::new(
 			import_notifications,
@@ -601,7 +601,7 @@ mod tests {
 		let (chain_state, import_notifications) = TestChainState::new();
 		let block_status = chain_state.block_status();
 
-		let (global_tx, global_rx) = futures::channel::mpsc::unbounded();
+		let (global_tx, global_rx) = tracing_unbounded("test");
 
 		let until_imported = UntilGlobalMessageBlocksImported::new(
 			import_notifications,
@@ -853,7 +853,7 @@ mod tests {
 		let (chain_state, import_notifications) = TestChainState::new();
 		let block_status = chain_state.block_status();
 
-		let (global_tx, global_rx) = futures::channel::mpsc::unbounded();
+		let (global_tx, global_rx) = tracing_unbounded("test");
 
 		let block_sync_requester = TestBlockSyncRequester::default();
 

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -206,6 +206,7 @@ mod tests {
 		let pool = Arc::new(TestPool(BasicPool::new(
 			Default::default(),
 			Arc::new(FullChainApi::new(client.clone())),
+			None,
 		).0));
 		client.execution_extensions()
 			.register_transaction_pool(Arc::downgrade(&pool.clone()) as _);

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -36,6 +36,7 @@ sc-block-builder = { version = "0.8.0-alpha.5", path = "../../client/block-build
 sc-keystore = { version = "2.0.0-alpha.5", path = "../keystore" }
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../primitives/blockchain" }
+sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 hash-db = { version = "0.15.2", default-features = false }
 parking_lot = "0.10.0"
 

--- a/client/rpc/src/author/tests.rs
+++ b/client/rpc/src/author/tests.rs
@@ -64,6 +64,7 @@ impl Default for TestSetup {
 		let pool = Arc::new(BasicPool::new(
 			Default::default(),
 			Arc::new(FullChainApi::new(client.clone())),
+			None,
 		).0);
 		TestSetup {
 			runtime: runtime::Runtime::new().expect("Failed to create runtime in test setup"),

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -20,9 +20,10 @@
 mod tests;
 
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
-use futures::{channel::{mpsc, oneshot}, compat::Compat};
+use futures::{channel::oneshot, compat::Compat};
 use sc_rpc_api::Receiver;
 use sp_runtime::traits::{self, Header as HeaderT};
+use sp_utils::mpsc::TracingUnboundedSender;
 
 use self::error::Result;
 
@@ -33,7 +34,7 @@ pub use self::gen_client::Client as SystemClient;
 /// System API implementation
 pub struct System<B: traits::Block> {
 	info: SystemInfo,
-	send_back: mpsc::UnboundedSender<Request<B>>,
+	send_back: TracingUnboundedSender<Request<B>>,
 }
 
 /// Request to be processed.
@@ -59,7 +60,7 @@ impl<B: traits::Block> System<B> {
 	/// reading from that channel and answering the requests.
 	pub fn new(
 		info: SystemInfo,
-		send_back: mpsc::UnboundedSender<Request<B>>,
+		send_back: TracingUnboundedSender<Request<B>>,
 	) -> Self {
 		System {
 			info,

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -18,9 +18,10 @@ use super::*;
 
 use sc_network::{self, PeerId};
 use sc_network::config::Roles;
+use sp_utils::mpsc::tracing_unbounded;
 use substrate_test_runtime_client::runtime::Block;
 use assert_matches::assert_matches;
-use futures::{prelude::*, channel::mpsc};
+use futures::prelude::*;
 use std::thread;
 
 struct Status {
@@ -44,7 +45,7 @@ impl Default for Status {
 fn api<T: Into<Option<Status>>>(sync: T) -> System<Block> {
 	let status = sync.into().unwrap_or_default();
 	let should_have_peers = !status.is_dev;
-	let (tx, rx) = mpsc::unbounded();
+	let (tx, rx) = tracing_unbounded("test");
 	thread::spawn(move || {
 		futures::executor::block_on(rx.for_each(move |request| {
 			match request {

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -31,7 +31,7 @@ wasm-timer = "0.2"
 exit-future = "0.2.0"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.12.0"
+sysinfo = "0.13.3"
 target_info = "0.1.0"
 sc-keystore = { version = "2.0.0-alpha.5", path = "../keystore" }
 sp-io = { version = "2.0.0-alpha.5", path = "../../primitives/io" }
@@ -49,11 +49,12 @@ sp-api = { version = "2.0.0-alpha.5", path = "../../primitives/api" }
 sc-client-db = { version = "0.8.0-alpha.5", path = "../db" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 sc-executor = { version = "0.8.0-alpha.5", path = "../executor" }
-sc-transaction-pool = { version = "2.0.0-alpha.5", path = "../transaction-pool" }
-sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
+sc-transaction-pool = { version = "2.0.0-rc3", path = "../transaction-pool" }
+sp-transaction-pool = { version = "2.0.0-rc2", path = "../../primitives/transaction-pool" }
 sc-rpc-server = { version = "2.0.0-alpha.5", path = "../rpc-servers" }
 sc-rpc = { version = "2.0.0-alpha.5", path = "../rpc" }
 sc-telemetry = { version = "2.0.0-alpha.5", path = "../telemetry" }
+sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 sc-offchain = { version = "2.0.0-alpha.5", path = "../offchain" }
 parity-multiaddr = { package = "parity-multiaddr", version = "0.7.3" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" , version = "0.8.0-alpha.5"}

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -907,63 +907,74 @@ ServiceBuilder<
 			spawn_handle.spawn(title, background_task);
 		}
 
+		// Inform the tx pool about imported and finalized blocks.
 		{
-			// block notifications
 			let txpool = Arc::downgrade(&transaction_pool);
+
+			let mut import_stream = client.import_notification_stream().map(|n| ChainEvent::NewBlock {
+				id: BlockId::Hash(n.hash),
+				header: n.header,
+				retracted: n.retracted,
+				is_new_best: n.is_new_best,
+			}).fuse();
+			let mut finality_stream = client.finality_notification_stream()
+				.map(|n| ChainEvent::Finalized::<TBl> { hash: n.hash })
+				.fuse();
+
+			let events = async move {
+				loop {
+					let evt = futures::select! {
+						evt = import_stream.next() => evt,
+						evt = finality_stream.next() => evt,
+						complete => return,
+					};
+
+					let txpool = txpool.upgrade();
+					if let Some((txpool, evt)) = txpool.and_then(|tp| evt.map(|evt| (tp, evt))) {
+						txpool.maintain(evt).await;
+					}
+				}
+			};
+
+			spawn_handle.spawn(
+				"txpool-notifications",
+				events,
+			);
+		}
+
+		// Inform the offchain worker about new imported blocks
+		{
 			let offchain = offchain_workers.as_ref().map(Arc::downgrade);
 			let notifications_spawn_handle = tasks_builder.spawn_handle();
 			let network_state_info: Arc<dyn NetworkStateInfo + Send + Sync> = network.clone();
 			let is_validator = config.roles.is_authority();
 
-			let (import_stream, finality_stream) = (
-				client.import_notification_stream().map(|n| ChainEvent::NewBlock {
-					id: BlockId::Hash(n.hash),
-					header: n.header,
-					retracted: n.retracted,
-					is_new_best: n.is_new_best,
-				}),
-				client.finality_notification_stream().map(|n| ChainEvent::Finalized {
-					hash: n.hash
-				})
-			);
-			let events = futures::stream::select(import_stream, finality_stream)
-				.for_each(move |event| {
-					// offchain worker is only interested in block import events
-					if let ChainEvent::NewBlock { ref header, is_new_best, .. } = event {
-						let offchain = offchain.as_ref().and_then(|o| o.upgrade());
-						match offchain {
-							Some(offchain) if is_new_best => {
-								notifications_spawn_handle.spawn(
-									"offchain-on-block",
-									offchain.on_block_imported(
-										&header,
-										network_state_info.clone(),
-										is_validator,
-									),
-								);
-							},
-							Some(_) => log::debug!(
-									target: "sc_offchain",
-									"Skipping offchain workers for non-canon block: {:?}",
-									header,
-								),
-							_ => {},
-						}
-					};
-
-					let txpool = txpool.upgrade();
-					if let Some(txpool) = txpool.as_ref() {
+			let events = client.import_notification_stream().for_each(move |n| {
+				let offchain = offchain.as_ref().and_then(|o| o.upgrade());
+				match offchain {
+					Some(offchain) if n.is_new_best => {
 						notifications_spawn_handle.spawn(
-							"txpool-maintain",
-							txpool.maintain(event),
+							"offchain-on-block",
+							offchain.on_block_imported(
+								&n.header,
+								network_state_info.clone(),
+								is_validator,
+							),
 						);
-					}
+					},
+					Some(_) => log::debug!(
+							target: "sc_offchain",
+							"Skipping offchain workers for non-canon block: {:?}",
+							n.header,
+						),
+					_ => {},
+				}
 
-					ready(())
-				});
+				ready(())
+			});
 
 			spawn_handle.spawn(
-				"txpool-and-offchain-notif",
+				"offchain-notifications",
 				events,
 			);
 		}

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -26,11 +26,11 @@ use sc_client_api::{
 	ExecutorProvider, CallExecutor
 };
 use sc_client::Client;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use sc_chain_spec::get_extension;
 use sp_consensus::import_queue::ImportQueue;
 use futures::{
 	Future, FutureExt, StreamExt,
-	channel::mpsc,
 	future::ready,
 };
 use sc_keystore::{Store as Keystore};
@@ -51,7 +51,7 @@ use std::{
 use wasm_timer::SystemTime;
 use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 use sc_telemetry::{telemetry, SUBSTRATE_INFO};
-use sp_transaction_pool::{MaintainedTransactionPool, ChainEvent};
+use sp_transaction_pool::MaintainedTransactionPool;
 use sp_blockchain;
 use prometheus_endpoint::{register, Gauge, U64, F64, Registry, PrometheusError, Opts, GaugeVec};
 
@@ -403,7 +403,17 @@ impl ServiceBuilder<(), (), (), (), (), (), (), (), (), (), ()> {
 
 impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 	ServiceBuilder<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp,
-	 	TExPool, TRpc, Backend> {
+		TExPool, TRpc, Backend> {
+
+	/// Returns a reference to the configuration that was stored in this builder.
+	pub fn config(&self) -> &Configuration {
+		&self.config
+	}
+
+	/// Returns a reference to the optional prometheus registry that was stored in this builder.
+	pub fn prometheus_registry(&self) -> Option<&Registry> {
+		self.config.prometheus_config.as_ref().map(|config| &config.registry)
+	}
 
 	/// Returns a reference to the client that was stored in this builder.
 	pub fn client(&self) -> &Arc<TCl> {
@@ -640,20 +650,14 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 	pub fn with_transaction_pool<UExPool>(
 		mut self,
 		transaction_pool_builder: impl FnOnce(
-			sc_transaction_pool::txpool::Options,
-			Arc<TCl>,
-			Option<TFchr>,
-		) -> Result<(UExPool, Option<BackgroundTask>), Error>
+			&Self,
+		) -> Result<(UExPool, Option<BackgroundTask>), Error>,
 	) -> Result<ServiceBuilder<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp,
 		UExPool, TRpc, Backend>, Error>
 	where TSc: Clone, TFchr: Clone {
-		let (transaction_pool, background_task) = transaction_pool_builder(
-			self.config.transaction_pool.clone(),
-			self.client.clone(),
-			self.fetcher.clone(),
-		)?;
+		let (transaction_pool, background_task) = transaction_pool_builder(&self)?;
 
-		if let Some(background_task) = background_task{
+		if let Some(background_task) = background_task {
 			self.background_tasks.push(("txpool-background", background_task));
 		}
 
@@ -769,7 +773,9 @@ ServiceBuilder<
 	TExec: 'static + sc_client::CallExecutor<TBl> + Send + Sync + Clone,
 	TSc: Clone,
 	TImpQu: 'static + ImportQueue<TBl>,
-	TExPool: MaintainedTransactionPool<Block=TBl, Hash = <TBl as BlockT>::Hash> + MallocSizeOfWasm + 'static,
+	TExPool: MaintainedTransactionPool<Block=TBl, Hash = <TBl as BlockT>::Hash> +
+		MallocSizeOfWasm +
+		'static,
 	TRpc: sc_rpc::RpcExtension<sc_rpc::Metadata> + Clone,
 {
 
@@ -820,7 +826,7 @@ ServiceBuilder<
 		)?;
 
 		// A side-channel for essential tasks to communicate shutdown.
-		let (essential_failed_tx, essential_failed_rx) = mpsc::unbounded();
+		let (essential_failed_tx, essential_failed_rx) = tracing_unbounded("mpsc_essential_tasks");
 
 		let import_queue = Box::new(import_queue);
 		let chain_info = client.chain_info();
@@ -908,39 +914,10 @@ ServiceBuilder<
 		}
 
 		// Inform the tx pool about imported and finalized blocks.
-		{
-			let txpool = Arc::downgrade(&transaction_pool);
-
-			let mut import_stream = client.import_notification_stream().map(|n| ChainEvent::NewBlock {
-				id: BlockId::Hash(n.hash),
-				header: n.header,
-				retracted: n.retracted,
-				is_new_best: n.is_new_best,
-			}).fuse();
-			let mut finality_stream = client.finality_notification_stream()
-				.map(|n| ChainEvent::Finalized::<TBl> { hash: n.hash })
-				.fuse();
-
-			let events = async move {
-				loop {
-					let evt = futures::select! {
-						evt = import_stream.next() => evt,
-						evt = finality_stream.next() => evt,
-						complete => return,
-					};
-
-					let txpool = txpool.upgrade();
-					if let Some((txpool, evt)) = txpool.and_then(|tp| evt.map(|evt| (tp, evt))) {
-						txpool.maintain(evt).await;
-					}
-				}
-			};
-
-			spawn_handle.spawn(
-				"txpool-notifications",
-				events,
-			);
-		}
+		spawn_handle.spawn(
+			"txpool-notifications",
+			sc_transaction_pool::notification_future(client.clone(), transaction_pool.clone()),
+		);
 
 		// Inform the offchain worker about new imported blocks
 		{
@@ -979,28 +956,10 @@ ServiceBuilder<
 			);
 		}
 
-		{
-			// extrinsic notifications
-			let network = Arc::downgrade(&network);
-			let transaction_pool_ = transaction_pool.clone();
-			let events = transaction_pool.import_notification_stream()
-				.for_each(move |hash| {
-					if let Some(network) = network.upgrade() {
-						network.propagate_extrinsic(hash);
-					}
-					let status = transaction_pool_.status();
-					telemetry!(SUBSTRATE_INFO; "txpool.import";
-						"ready" => status.ready,
-						"future" => status.future
-					);
-					ready(())
-				});
-
-			spawn_handle.spawn(
-				"telemetry-on-block",
-				events,
-			);
-		}
+		spawn_handle.spawn(
+			"on-transaction-imported",
+			extrinsic_notifications(transaction_pool.clone(), network.clone()),
+		);
 
 		// Prometheus metrics.
 		let metrics = if let Some(PrometheusConfig { port, registry }) = config.prometheus_config.clone() {
@@ -1035,7 +994,7 @@ ServiceBuilder<
 		let client_ = client.clone();
 		let mut sys = System::new();
 		let self_pid = get_current_pid().ok();
-		let (state_tx, state_rx) = mpsc::unbounded::<(NetworkStatus<_>, NetworkState)>();
+		let (state_tx, state_rx) = tracing_unbounded::<(NetworkStatus<_>, NetworkState)>("mpsc_netstat1");
 		network_status_sinks.lock().push(std::time::Duration::from_millis(5000), state_tx);
 		let tel_task = state_rx.for_each(move |(net_status, _)| {
 			let info = client_.usage_info();
@@ -1120,7 +1079,7 @@ ServiceBuilder<
 		);
 
 		// Periodically send the network state to the telemetry.
-		let (netstat_tx, netstat_rx) = mpsc::unbounded::<(NetworkStatus<_>, NetworkState)>();
+		let (netstat_tx, netstat_rx) = tracing_unbounded::<(NetworkStatus<_>, NetworkState)>("mpsc_netstat2");
 		network_status_sinks.lock().push(std::time::Duration::from_secs(30), netstat_tx);
 		let tel_task_2 = netstat_rx.for_each(move |(_, network_state)| {
 			telemetry!(
@@ -1136,7 +1095,7 @@ ServiceBuilder<
 		);
 
 		// RPC
-		let (system_rpc_tx, system_rpc_rx) = mpsc::unbounded();
+		let (system_rpc_tx, system_rpc_rx) = tracing_unbounded("mpsc_system_rpc");
 		let gen_handler = || {
 			use sc_rpc::{chain, state, author, system, offchain};
 
@@ -1217,7 +1176,7 @@ ServiceBuilder<
 			),
 		);
 
-		let telemetry_connection_sinks: Arc<Mutex<Vec<futures::channel::mpsc::UnboundedSender<()>>>> = Default::default();
+		let telemetry_connection_sinks: Arc<Mutex<Vec<TracingUnboundedSender<()>>>> = Default::default();
 
 		// Telemetry
 		let telemetry = config.telemetry_endpoints.clone().map(|endpoints| {
@@ -1278,7 +1237,7 @@ ServiceBuilder<
 
 		Ok(Service {
 			client,
-			task_manager: tasks_builder.into_task_manager(config.task_executor.ok_or(Error::TaskExecutorRequired)?),
+			task_manager:  tasks_builder.into_task_manager(config.task_executor.ok_or(Error::TaskExecutorRequired)?),
 			network,
 			network_status_sinks,
 			select_chain,
@@ -1295,4 +1254,26 @@ ServiceBuilder<
 			prometheus_registry: config.prometheus_config.map(|config| config.registry)
 		})
 	}
+}
+
+async fn extrinsic_notifications<TBl, TExPool>(
+	transaction_pool: Arc<TExPool>,
+	network: Arc<NetworkService<TBl, <TBl as BlockT>::Hash>>
+)
+	where
+		TBl: BlockT,
+		TExPool: MaintainedTransactionPool<Block=TBl, Hash = <TBl as BlockT>::Hash>,
+{
+	// extrinsic notifications
+	transaction_pool.import_notification_stream()
+		.for_each(move |hash| {
+			network.propagate_extrinsic(hash);
+			let status = transaction_pool.status();
+			telemetry!(SUBSTRATE_INFO; "txpool.import";
+				"ready" => status.ready,
+				"future" => status.future
+			);
+			ready(())
+		})
+		.await;
 }

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -40,7 +40,6 @@ use parking_lot::Mutex;
 use sc_client::Client;
 use futures::{
 	Future, FutureExt, Stream, StreamExt,
-	channel::mpsc,
 	compat::*,
 	sink::SinkExt,
 	task::{Spawn, FutureObj, SpawnError},
@@ -51,6 +50,7 @@ use codec::{Encode, Decode};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{NumberFor, Block as BlockT};
 use parity_util_mem::MallocSizeOf;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver,  TracingUnboundedSender};
 
 pub use self::error::Error;
 pub use self::builder::{
@@ -98,13 +98,13 @@ pub struct Service<TBl, TCl, TSc, TNetStatus, TNet, TTxPool, TOc> {
 	transaction_pool: Arc<TTxPool>,
 	/// Send a signal when a spawned essential task has concluded. The next time
 	/// the service future is polled it should complete with an error.
-	essential_failed_tx: mpsc::UnboundedSender<()>,
+	essential_failed_tx: TracingUnboundedSender<()>,
 	/// A receiver for spawned essential-tasks concluding.
-	essential_failed_rx: mpsc::UnboundedReceiver<()>,
+	essential_failed_rx: TracingUnboundedReceiver<()>,
 	rpc_handlers: sc_rpc_server::RpcHandler<sc_rpc::Metadata>,
 	_rpc: Box<dyn std::any::Any + Send + Sync>,
 	_telemetry: Option<sc_telemetry::Telemetry>,
-	_telemetry_on_connect_sinks: Arc<Mutex<Vec<futures::channel::mpsc::UnboundedSender<()>>>>,
+	_telemetry_on_connect_sinks: Arc<Mutex<Vec<TracingUnboundedSender<()>>>>,
 	_offchain_workers: Option<Arc<TOc>>,
 	keystore: sc_keystore::KeyStorePtr,
 	marker: PhantomData<TBl>,
@@ -130,7 +130,7 @@ pub trait AbstractService: 'static + Future<Output = Result<(), Error>> +
 	type TransactionPool: TransactionPool<Block = Self::Block> + MallocSizeOfWasm;
 
 	/// Get event stream for telemetry connection established events.
-	fn telemetry_on_connect_stream(&self) -> futures::channel::mpsc::UnboundedReceiver<()>;
+	fn telemetry_on_connect_stream(&self) -> TracingUnboundedReceiver<()>;
 
 	/// return a shared instance of Telemetry (if enabled)
 	fn telemetry(&self) -> Option<sc_telemetry::Telemetry>;
@@ -171,7 +171,7 @@ pub trait AbstractService: 'static + Future<Output = Result<(), Error>> +
 		-> Arc<NetworkService<Self::Block, <Self::Block as BlockT>::Hash>>;
 
 	/// Returns a receiver that periodically receives a status of the network.
-	fn network_status(&self, interval: Duration) -> mpsc::UnboundedReceiver<(NetworkStatus<Self::Block>, NetworkState)>;
+	fn network_status(&self, interval: Duration) -> TracingUnboundedReceiver<(NetworkStatus<Self::Block>, NetworkState)>;
 
 	/// Get shared transaction pool instance.
 	fn transaction_pool(&self) -> Arc<Self::TransactionPool>;
@@ -203,8 +203,8 @@ where
 	type SelectChain = TSc;
 	type TransactionPool = TExPool;
 
-	fn telemetry_on_connect_stream(&self) -> futures::channel::mpsc::UnboundedReceiver<()> {
-		let (sink, stream) = futures::channel::mpsc::unbounded();
+	fn telemetry_on_connect_stream(&self) -> TracingUnboundedReceiver<()> {
+		let (sink, stream) = tracing_unbounded("mpsc_telemetry_on_connect");
 		self._telemetry_on_connect_sinks.lock().push(sink);
 		stream
 	}
@@ -259,8 +259,8 @@ where
 		self.network.clone()
 	}
 
-	fn network_status(&self, interval: Duration) -> mpsc::UnboundedReceiver<(NetworkStatus<Self::Block>, NetworkState)> {
-		let (sink, stream) = mpsc::unbounded();
+	fn network_status(&self, interval: Duration) -> TracingUnboundedReceiver<(NetworkStatus<Self::Block>, NetworkState)> {
+		let (sink, stream) = tracing_unbounded("mpsc_network_status");
 		self.network_status_sinks.lock().push(interval, sink);
 		stream
 	}
@@ -326,7 +326,7 @@ fn build_network_future<
 	mut network: sc_network::NetworkWorker<B, H>,
 	client: Arc<C>,
 	status_sinks: Arc<Mutex<status_sinks::StatusSinks<(NetworkStatus<B>, NetworkState)>>>,
-	mut rpc_rx: mpsc::UnboundedReceiver<sc_rpc::system::Request<B>>,
+	mut rpc_rx: TracingUnboundedReceiver<sc_rpc::system::Request<B>>,
 	should_have_peers: bool,
 ) -> impl Future<Output = ()> {
 	let mut imported_blocks_stream = client.import_notification_stream().fuse();
@@ -674,6 +674,7 @@ mod tests {
 		let pool = Arc::new(BasicPool::new(
 			Default::default(),
 			Arc::new(FullChainApi::new(client.clone())),
+			None,
 		).0);
 		let source = sp_runtime::transaction_validity::TransactionSource::External;
 		let best = longest_chain.best_chain().unwrap();

--- a/client/service/src/status_sinks.rs
+++ b/client/service/src/status_sinks.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use futures::{Stream, stream::futures_unordered::FuturesUnordered, channel::mpsc};
+use futures::{Stream, stream::futures_unordered::FuturesUnordered};
 use std::time::Duration;
 use std::pin::Pin;
 use std::task::{Poll, Context};
 use futures_timer::Delay;
+use sp_utils::mpsc::TracingUnboundedSender;
 
 /// Holds a list of `UnboundedSender`s, each associated with a certain time period. Every time the
 /// period elapses, we push an element on the sender.
@@ -31,7 +32,7 @@ pub struct StatusSinks<T> {
 struct YieldAfter<T> {
 	delay: Delay,
 	interval: Duration,
-	sender: Option<mpsc::UnboundedSender<T>>,
+	sender: Option<TracingUnboundedSender<T>>,
 }
 
 impl<T> StatusSinks<T> {
@@ -45,7 +46,7 @@ impl<T> StatusSinks<T> {
 	/// Adds a sender to the collection.
 	///
 	/// The `interval` is the time period between two pushes on the sender.
-	pub fn push(&mut self, interval: Duration, sender: mpsc::UnboundedSender<T>) {
+	pub fn push(&mut self, interval: Duration, sender: TracingUnboundedSender<T>) {
 		self.entries.push(YieldAfter {
 			delay: Delay::new(interval),
 			interval,
@@ -88,7 +89,7 @@ impl<T> StatusSinks<T> {
 }
 
 impl<T> futures::Future for YieldAfter<T> {
-	type Output = (mpsc::UnboundedSender<T>, Duration);
+	type Output = (TracingUnboundedSender<T>, Duration);
 
 	fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
 		let this = Pin::into_inner(self);
@@ -107,8 +108,8 @@ impl<T> futures::Future for YieldAfter<T> {
 #[cfg(test)]
 mod tests {
 	use super::StatusSinks;
+	use sp_utils::mpsc::tracing_unbounded;
 	use futures::prelude::*;
-	use futures::channel::mpsc;
 	use std::time::Duration;
 	use std::task::Poll;
 
@@ -119,7 +120,7 @@ mod tests {
 
 		let mut status_sinks = StatusSinks::new();
 
-		let (tx, rx) = mpsc::unbounded();
+		let (tx, rx) = tracing_unbounded("test");
 		status_sinks.push(Duration::from_millis(100), tx);
 
 		let mut val_order = 5;

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -1,34 +1,42 @@
 [package]
 name = "sc-transaction-pool"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-license = "GPL-3.0"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate transaction pool implementation."
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 derive_more = "0.99.2"
 futures = { version = "0.3.1", features = ["compat"] }
 futures-diagnose = "1.0"
+intervalier = "0.4.0"
 log = "0.4.8"
+parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
 parking_lot = "0.10.0"
-wasm-timer = "0.2"
-sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core" }
-sp-api = { version = "2.0.0-alpha.5", path = "../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
-sc-transaction-graph = { version = "2.0.0-alpha.5", path = "./graph" }
-sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-alpha.5"}
 sc-client-api = { version = "2.0.0-alpha.5", path = "../api" }
+sc-transaction-graph = { version = "2.0.0-rc3", path = "./graph" }
+sp-api = { version = "2.0.0-alpha.5", path = "../../primitives/api" }
+sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
+sp-tracing = { version = "2.0.0-rc3", path = "../../primitives/tracing" }
+sp-transaction-pool = { version = "2.0.0-rc2", path = "../../primitives/transaction-pool" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../primitives/blockchain" }
-futures-timer = "2.0"
-parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
+sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
+wasm-timer = "0.2"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 hex = "0.4"
 sp-keyring = { version = "2.0.0-alpha.5", path = "../../primitives/keyring" }
-substrate-test-runtime-transaction-pool = { version = "2.0.0-dev", path = "../../test-utils/runtime/transaction-pool" }
-substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
+sp-consensus = { version = "0.8.0-alpha.5", path = "../../primitives/consensus/common" }
+substrate-test-runtime-transaction-pool = { version = "2.0.0-alpha.5", path = "../../test-utils/runtime/transaction-pool" }
+substrate-test-runtime-client = { version = "2.0.0-alpha.5", path = "../../test-utils/runtime/client" }
+sc-block-builder = { version = "0.8.0-alpha.5", path = "../block-builder" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "sc-transaction-graph"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-license = "GPL-3.0"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Generic Transaction Pool"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
@@ -16,16 +19,17 @@ parking_lot = "0.10.0"
 serde = { version = "1.0.101", features = ["derive"] }
 wasm-timer = "0.2"
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockchain" }
+sp-utils = { version = "2.0.0-rc3", path = "../../../primitives/utils" }
 sp-core = { version = "2.0.0-alpha.5", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
-sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../../primitives/transaction-pool" }
-parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
+sp-transaction-pool = { version = "2.0.0-rc2", path = "../../../primitives/transaction-pool" }
+parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
 linked-hash-map = "0.5.2"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-substrate-test-runtime = { version = "2.0.0-dev", path = "../../../test-utils/runtime" }
+substrate-test-runtime = { version = "2.0.0-alpha.5", path = "../../../test-utils/runtime" }
 criterion = "0.3"
 
 [[bench]]

--- a/client/transaction-pool/graph/benches/basics.rs
+++ b/client/transaction-pool/graph/benches/basics.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
@@ -49,7 +51,6 @@ fn to_tag(nonce: u64, from: AccountId) -> Tag {
 
 impl ChainApi for TestApi {
 	type Block = Block;
-	type Hash = H256;
 	type Error = sp_transaction_pool::error::Error;
 	type ValidationFuture = Ready<sp_transaction_pool::error::Result<TransactionValidity>>;
 	type BodyFuture = Ready<sp_transaction_pool::error::Result<Option<Vec<Extrinsic>>>>;
@@ -105,7 +106,7 @@ impl ChainApi for TestApi {
 		})
 	}
 
-	fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (Self::Hash, usize) {
+	fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (H256, usize) {
 		let encoded = uxt.encode();
 		(blake2_256(&encoded).into(), encoded.len())
 	}

--- a/client/transaction-pool/graph/src/base_pool.rs
+++ b/client/transaction-pool/graph/src/base_pool.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! A basic version of the dependency graph.
 //!

--- a/client/transaction-pool/graph/src/error.rs
+++ b/client/transaction-pool/graph/src/error.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Transaction pool errors.
 

--- a/client/transaction-pool/graph/src/future.rs
+++ b/client/transaction-pool/graph/src/future.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
 	collections::{HashMap, HashSet},

--- a/client/transaction-pool/graph/src/lib.rs
+++ b/client/transaction-pool/graph/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Generic Transaction Pool
 //!
@@ -30,14 +32,13 @@ mod pool;
 mod ready;
 mod rotator;
 mod validated_pool;
+mod tracked_map;
 
 pub mod base_pool;
 pub mod watcher;
 
 pub use self::base_pool::Transaction;
 pub use self::pool::{
-	Pool,
-	Options, ChainApi, EventStream, ExtrinsicFor,
-	BlockHash, ExHash, NumberFor, TransactionFor,
-	ValidatedTransaction,
+	Pool, Options, ChainApi, EventStream, ExtrinsicFor, ExtrinsicHash,
+	BlockHash, NumberFor, TransactionFor, ValidatedTransaction,
 };

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -1,62 +1,59 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
-	hash,
 	collections::HashMap,
 	sync::Arc,
 };
 
-use crate::base_pool as base;
-use crate::watcher::Watcher;
-use serde::Serialize;
+use crate::{base_pool as base, watcher::Watcher};
 
-use futures::{
-	Future, FutureExt,
-	channel::mpsc,
-};
+use futures::{Future, FutureExt};
 use sp_runtime::{
 	generic::BlockId,
-	traits::{self, SaturatedConversion},
+	traits::{self, SaturatedConversion, Block as BlockT},
 	transaction_validity::{
 		TransactionValidity, TransactionTag as Tag, TransactionValidityError, TransactionSource,
 	},
 };
 use sp_transaction_pool::error;
 use wasm_timer::Instant;
+use sp_utils::mpsc::TracingUnboundedReceiver;
 
 use crate::validated_pool::ValidatedPool;
 pub use crate::validated_pool::ValidatedTransaction;
 
 /// Modification notification event stream type;
-pub type EventStream<H> = mpsc::UnboundedReceiver<H>;
+pub type EventStream<H> = TracingUnboundedReceiver<H>;
 
-/// Extrinsic hash type for a pool.
-pub type ExHash<A> = <A as ChainApi>::Hash;
 /// Block hash type for a pool.
 pub type BlockHash<A> = <<A as ChainApi>::Block as traits::Block>::Hash;
+/// Extrinsic hash type for a pool.
+pub type ExtrinsicHash<A> = <<A as ChainApi>::Block as traits::Block>::Hash;
 /// Extrinsic type for a pool.
 pub type ExtrinsicFor<A> = <<A as ChainApi>::Block as traits::Block>::Extrinsic;
 /// Block number type for the ChainApi
 pub type NumberFor<A> = traits::NumberFor<<A as ChainApi>::Block>;
 /// A type of transaction stored in the pool
-pub type TransactionFor<A> = Arc<base::Transaction<ExHash<A>, ExtrinsicFor<A>>>;
+pub type TransactionFor<A> = Arc<base::Transaction<ExtrinsicHash<A>, ExtrinsicFor<A>>>;
 /// A type of validated transaction stored in the pool.
 pub type ValidatedTransactionFor<A> = ValidatedTransaction<
-	ExHash<A>,
+	ExtrinsicHash<A>,
 	ExtrinsicFor<A>,
 	<A as ChainApi>::Error,
 >;
@@ -64,15 +61,15 @@ pub type ValidatedTransactionFor<A> = ValidatedTransaction<
 /// Concrete extrinsic validation and query logic.
 pub trait ChainApi: Send + Sync {
 	/// Block type.
-	type Block: traits::Block;
-	/// Transaction Hash type
-	type Hash: hash::Hash + Eq + traits::Member + Serialize;
+	type Block: BlockT;
 	/// Error type.
 	type Error: From<error::Error> + error::IntoPoolError;
 	/// Validate transaction future.
 	type ValidationFuture: Future<Output=Result<TransactionValidity, Self::Error>> + Send + Unpin;
 	/// Body future (since block body might be remote)
-	type BodyFuture: Future<Output = Result<Option<Vec<<Self::Block as traits::Block>::Extrinsic>>, Self::Error>> + Unpin + Send + 'static;
+	type BodyFuture: Future<
+		Output = Result<Option<Vec<<Self::Block as traits::Block>::Extrinsic>>, Self::Error>
+	> + Unpin + Send + 'static;
 
 	/// Verify extrinsic at given block.
 	fn validate_transaction(
@@ -83,13 +80,19 @@ pub trait ChainApi: Send + Sync {
 	) -> Self::ValidationFuture;
 
 	/// Returns a block number given the block id.
-	fn block_id_to_number(&self, at: &BlockId<Self::Block>) -> Result<Option<NumberFor<Self>>, Self::Error>;
+	fn block_id_to_number(
+		&self,
+		at: &BlockId<Self::Block>,
+	) -> Result<Option<NumberFor<Self>>, Self::Error>;
 
 	/// Returns a block hash given the block id.
-	fn block_id_to_hash(&self, at: &BlockId<Self::Block>) -> Result<Option<BlockHash<Self>>, Self::Error>;
+	fn block_id_to_hash(
+		&self,
+		at: &BlockId<Self::Block>,
+	) -> Result<Option<<Self::Block as BlockT>::Hash>, Self::Error>;
 
 	/// Returns hash and encoding length of the extrinsic.
-	fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (Self::Hash, usize);
+	fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (ExtrinsicHash<Self>, usize);
 
 	/// Returns a block body given the block id.
 	fn block_body(&self, at: &BlockId<Self::Block>) -> Self::BodyFuture;
@@ -130,7 +133,6 @@ pub struct Pool<B: ChainApi> {
 #[cfg(not(target_os = "unknown"))]
 impl<B: ChainApi> parity_util_mem::MallocSizeOf for Pool<B>
 where
-	B::Hash: parity_util_mem::MallocSizeOf,
 	ExtrinsicFor<B>: parity_util_mem::MallocSizeOf,
 {
 	fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
@@ -153,7 +155,7 @@ impl<B: ChainApi> Pool<B> {
 		source: TransactionSource,
 		xts: T,
 		force: bool,
-	) -> Result<Vec<Result<ExHash<B>, B::Error>>, B::Error> where
+	) -> Result<Vec<Result<ExtrinsicHash<B>, B::Error>>, B::Error> where
 		T: IntoIterator<Item=ExtrinsicFor<B>>,
 	{
 		let validated_pool = self.validated_pool.clone();
@@ -172,7 +174,7 @@ impl<B: ChainApi> Pool<B> {
 		at: &BlockId<B::Block>,
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
-	) -> Result<ExHash<B>, B::Error> {
+	) -> Result<ExtrinsicHash<B>, B::Error> {
 		self.submit_at(at, source, std::iter::once(xt), false)
 			.map(|import_result| import_result.and_then(|mut import_result| import_result
 				.pop()
@@ -187,7 +189,7 @@ impl<B: ChainApi> Pool<B> {
 		at: &BlockId<B::Block>,
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
-	) -> Result<Watcher<ExHash<B>, BlockHash<B>>, B::Error> {
+	) -> Result<Watcher<ExtrinsicHash<B>, ExtrinsicHash<B>>, B::Error> {
 		let block_number = self.resolve_block_number(at)?;
 		let (_, tx) = self.verify_one(
 			at, block_number, source, xt, false
@@ -198,7 +200,7 @@ impl<B: ChainApi> Pool<B> {
 	/// Resubmit some transaction that were validated elsewhere.
 	pub fn resubmit(
 		&self,
-		revalidated_transactions: HashMap<ExHash<B>, ValidatedTransactionFor<B>>,
+		revalidated_transactions: HashMap<ExtrinsicHash<B>, ValidatedTransactionFor<B>>,
 	) {
 
 		let now = Instant::now();
@@ -215,7 +217,11 @@ impl<B: ChainApi> Pool<B> {
 	/// Used to clear the pool from transactions that were part of recently imported block.
 	/// The main difference from the `prune` is that we do not revalidate any transactions
 	/// and ignore unknown passed hashes.
-	pub fn prune_known(&self, at: &BlockId<B::Block>, hashes: &[ExHash<B>]) -> Result<(), B::Error> {
+	pub fn prune_known(
+		&self,
+		at: &BlockId<B::Block>,
+		hashes: &[ExtrinsicHash<B>],
+	) -> Result<(), B::Error> {
 		// Get details of all extrinsics that are already in the pool
 		let in_pool_tags = self.validated_pool.extrinsics_tags(hashes)
 			.into_iter().filter_map(|x| x).flat_map(|x| x);
@@ -299,7 +305,7 @@ impl<B: ChainApi> Pool<B> {
 		&self,
 		at: &BlockId<B::Block>,
 		tags: impl IntoIterator<Item=Tag>,
-		known_imported_hashes: impl IntoIterator<Item=ExHash<B>> + Clone,
+		known_imported_hashes: impl IntoIterator<Item=ExtrinsicHash<B>> + Clone,
 	) -> Result<(), B::Error> {
 		log::debug!(target: "txpool", "Pruning at {:?}", at);
 		// Prune all transactions that provide given tags
@@ -336,7 +342,7 @@ impl<B: ChainApi> Pool<B> {
 	}
 
 	/// Returns transaction hash
-	pub fn hash_of(&self, xt: &ExtrinsicFor<B>) -> ExHash<B> {
+	pub fn hash_of(&self, xt: &ExtrinsicFor<B>) -> ExtrinsicHash<B> {
 		self.validated_pool.api().hash_and_length(xt).0
 	}
 
@@ -353,7 +359,7 @@ impl<B: ChainApi> Pool<B> {
 		at: &BlockId<B::Block>,
 		xts: impl IntoIterator<Item=(TransactionSource, ExtrinsicFor<B>)>,
 		force: bool,
-	) -> Result<HashMap<ExHash<B>, ValidatedTransactionFor<B>>, B::Error> {
+	) -> Result<HashMap<ExtrinsicHash<B>, ValidatedTransactionFor<B>>, B::Error> {
 		// we need a block number to compute tx validity
 		let block_number = self.resolve_block_number(at)?;
 		let mut result = HashMap::new();
@@ -379,7 +385,7 @@ impl<B: ChainApi> Pool<B> {
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
 		force: bool,
-	) -> (ExHash<B>, ValidatedTransactionFor<B>) {
+	) -> (ExtrinsicHash<B>, ValidatedTransactionFor<B>) {
 		let (hash, bytes) = self.validated_pool.api().hash_and_length(&xt);
 		if !force && self.validated_pool.is_banned(&hash) {
 			return (
@@ -444,9 +450,11 @@ mod tests {
 	use futures::executor::block_on;
 	use super::*;
 	use sp_transaction_pool::TransactionStatus;
-	use sp_runtime::transaction_validity::{ValidTransaction, InvalidTransaction, TransactionSource};
+	use sp_runtime::{
+		transaction_validity::{ValidTransaction, InvalidTransaction, TransactionSource}, traits::Hash,
+	};
 	use codec::Encode;
-	use substrate_test_runtime::{Block, Extrinsic, Transfer, H256, AccountId};
+	use substrate_test_runtime::{Block, Extrinsic, Transfer, H256, AccountId, Hashing};
 	use assert_matches::assert_matches;
 	use wasm_timer::Instant;
 	use crate::base_pool::Limit;
@@ -457,14 +465,13 @@ mod tests {
 	#[derive(Clone, Debug, Default)]
 	struct TestApi {
 		delay: Arc<Mutex<Option<std::sync::mpsc::Receiver<()>>>>,
-		invalidate: Arc<Mutex<HashSet<u64>>>,
-		clear_requirements: Arc<Mutex<HashSet<u64>>>,
-		add_requirements: Arc<Mutex<HashSet<u64>>>,
+		invalidate: Arc<Mutex<HashSet<H256>>>,
+		clear_requirements: Arc<Mutex<HashSet<H256>>>,
+		add_requirements: Arc<Mutex<HashSet<H256>>>,
 	}
 
 	impl ChainApi for TestApi {
 		type Block = Block;
-		type Hash = u64;
 		type Error = error::Error;
 		type ValidationFuture = futures::future::Ready<error::Result<TransactionValidity>>;
 		type BodyFuture = futures::future::Ready<error::Result<Option<Vec<Extrinsic>>>>;
@@ -518,7 +525,10 @@ mod tests {
 		}
 
 		/// Returns a block number given the block id.
-		fn block_id_to_number(&self, at: &BlockId<Self::Block>) -> Result<Option<NumberFor<Self>>, Self::Error> {
+		fn block_id_to_number(
+			&self,
+			at: &BlockId<Self::Block>,
+		) -> Result<Option<NumberFor<Self>>, Self::Error> {
 			Ok(match at {
 				BlockId::Number(num) => Some(*num),
 				BlockId::Hash(_) => None,
@@ -526,7 +536,10 @@ mod tests {
 		}
 
 		/// Returns a block hash given the block id.
-		fn block_id_to_hash(&self, at: &BlockId<Self::Block>) -> Result<Option<BlockHash<Self>>, Self::Error> {
+		fn block_id_to_hash(
+			&self,
+			at: &BlockId<Self::Block>,
+		) -> Result<Option<<Self::Block as BlockT>::Hash>, Self::Error> {
 			Ok(match at {
 				BlockId::Number(num) => Some(H256::from_low_u64_be(*num)).into(),
 				BlockId::Hash(_) => None,
@@ -534,12 +547,10 @@ mod tests {
 		}
 
 		/// Hash the extrinsic.
-		fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (Self::Hash, usize) {
-			let len = uxt.encode().len();
-			(
-				(H256::from(uxt.transfer().from.clone()).to_low_u64_be() << 5) + uxt.transfer().nonce,
-				len
-			)
+		fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (BlockHash<Self>, usize) {
+			let encoded = uxt.encode();
+			let len = encoded.len();
+			(Hashing::hash(&encoded), len)
 		}
 
 		fn block_body(&self, _id: &BlockId<Self::Block>) -> Self::BodyFuture {
@@ -599,19 +610,19 @@ mod tests {
 
 	#[test]
 	fn should_notify_about_pool_events() {
-		let stream = {
+		let (stream, hash0, hash1) = {
 			// given
 			let pool = pool();
 			let stream = pool.validated_pool().import_notification_stream();
 
 			// when
-			let _hash = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Transfer {
+			let hash0 = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Transfer {
 				from: AccountId::from_h256(H256::from_low_u64_be(1)),
 				to: AccountId::from_h256(H256::from_low_u64_be(2)),
 				amount: 5,
 				nonce: 0,
 			}))).unwrap();
-			let _hash = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Transfer {
+			let hash1 = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt(Transfer {
 				from: AccountId::from_h256(H256::from_low_u64_be(1)),
 				to: AccountId::from_h256(H256::from_low_u64_be(2)),
 				amount: 5,
@@ -627,13 +638,14 @@ mod tests {
 
 			assert_eq!(pool.validated_pool().status().ready, 2);
 			assert_eq!(pool.validated_pool().status().future, 1);
-			stream
+
+			(stream, hash0, hash1)
 		};
 
 		// then
 		let mut it = futures::executor::block_on_stream(stream);
-		assert_eq!(it.next(), Some(32));
-		assert_eq!(it.next(), Some(33));
+		assert_eq!(it.next(), Some(hash0));
+		assert_eq!(it.next(), Some(hash1));
 		assert_eq!(it.next(), None);
 	}
 
@@ -795,7 +807,10 @@ mod tests {
 			// then
 			let mut stream = futures::executor::block_on_stream(watcher.into_stream());
 			assert_eq!(stream.next(), Some(TransactionStatus::Ready));
-			assert_eq!(stream.next(), Some(TransactionStatus::InBlock(H256::from_low_u64_be(2).into())));
+			assert_eq!(
+				stream.next(),
+				Some(TransactionStatus::InBlock(H256::from_low_u64_be(2).into())),
+			);
 		}
 
 		#[test]
@@ -812,14 +827,19 @@ mod tests {
 			assert_eq!(pool.validated_pool().status().future, 0);
 
 			// when
-			block_on(pool.prune_tags(&BlockId::Number(2), vec![vec![0u8]], vec![2u64])).unwrap();
+			block_on(
+				pool.prune_tags(&BlockId::Number(2), vec![vec![0u8]], vec![watcher.hash().clone()]),
+			).unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 0);
 			assert_eq!(pool.validated_pool().status().future, 0);
 
 			// then
 			let mut stream = futures::executor::block_on_stream(watcher.into_stream());
 			assert_eq!(stream.next(), Some(TransactionStatus::Ready));
-			assert_eq!(stream.next(), Some(TransactionStatus::InBlock(H256::from_low_u64_be(2).into())));
+			assert_eq!(
+				stream.next(),
+				Some(TransactionStatus::InBlock(H256::from_low_u64_be(2).into())),
+			);
 		}
 
 		#[test]

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
 	collections::{HashMap, HashSet, BTreeSet},
@@ -23,15 +25,17 @@ use std::{
 
 use serde::Serialize;
 use log::trace;
-use parking_lot::RwLock;
 use sp_runtime::traits::Member;
 use sp_runtime::transaction_validity::{
 	TransactionTag as Tag,
 };
 use sp_transaction_pool::error;
 
-use crate::future::WaitingTransaction;
-use crate::base_pool::Transaction;
+use crate::{
+	base_pool::Transaction,
+	future::WaitingTransaction,
+	tracked_map::{self, ReadOnlyTrackedMap, TrackedMap},
+};
 
 /// An in-pool transaction reference.
 ///
@@ -111,9 +115,15 @@ pub struct ReadyTransactions<Hash: hash::Hash + Eq, Ex> {
 	/// tags that are provided by Ready transactions
 	provided_tags: HashMap<Tag, Hash>,
 	/// Transactions that are ready (i.e. don't have any requirements external to the pool)
-	ready: Arc<RwLock<HashMap<Hash, ReadyTx<Hash, Ex>>>>,
+	ready: TrackedMap<Hash, ReadyTx<Hash, Ex>>,
 	/// Best transactions that are ready to be included to the block without any other previous transaction.
 	best: BTreeSet<TransactionRef<Hash, Ex>>,
+}
+
+impl<Hash, Ex> tracked_map::Size for ReadyTx<Hash, Ex> {
+	fn size(&self) -> usize {
+		self.transaction.transaction.bytes
+	}
 }
 
 impl<Hash: hash::Hash + Eq, Ex> Default for ReadyTransactions<Hash, Ex> {
@@ -466,18 +476,18 @@ impl<Hash: hash::Hash + Member + Serialize, Ex> ReadyTransactions<Hash, Ex> {
 
 	/// Returns number of transactions in this queue.
 	pub fn len(&self) -> usize {
-		self.ready.read().len()
+		self.ready.len()
 	}
 
 	/// Returns sum of encoding lengths of all transactions in this queue.
 	pub fn bytes(&self) -> usize {
-		self.ready.read().values().fold(0, |acc, tx| acc + tx.transaction.transaction.bytes)
+		self.ready.bytes()
 	}
 }
 
 /// Iterator of ready transactions ordered by priority.
 pub struct BestIterator<Hash, Ex> {
-	all: Arc<RwLock<HashMap<Hash, ReadyTx<Hash, Ex>>>>,
+	all: ReadOnlyTrackedMap<Hash, ReadyTx<Hash, Ex>>,
 	awaiting: HashMap<Hash, (usize, TransactionRef<Hash, Ex>)>,
 	best: BTreeSet<TransactionRef<Hash, Ex>>,
 }

--- a/client/transaction-pool/graph/src/rotator.rs
+++ b/client/transaction-pool/graph/src/rotator.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Rotate extrinsic inside the pool.
 //!

--- a/client/transaction-pool/graph/src/tracked_map.rs
+++ b/client/transaction-pool/graph/src/tracked_map.rs
@@ -1,0 +1,189 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{
+	collections::HashMap,
+	sync::{Arc, atomic::{AtomicIsize, Ordering as AtomicOrdering}},
+};
+use parking_lot::{RwLock, RwLockWriteGuard, RwLockReadGuard};
+
+/// Something that can report it's size.
+pub trait Size {
+	fn size(&self) -> usize;
+}
+
+/// Map with size tracking.
+///
+/// Size reported might be slightly off and only approximately true.
+#[derive(Debug, parity_util_mem::MallocSizeOf)]
+pub struct TrackedMap<K, V> {
+	index: Arc<RwLock<HashMap<K, V>>>,
+	bytes: AtomicIsize,
+	length: AtomicIsize,
+}
+
+impl<K, V> Default for TrackedMap<K, V> {
+	fn default() -> Self {
+		Self {
+			index: Arc::new(HashMap::default().into()),
+			bytes: 0.into(),
+			length: 0.into(),
+		}
+	}
+}
+
+impl<K, V> TrackedMap<K, V> {
+	/// Current tracked length of the content.
+	pub fn len(&self) -> usize {
+		std::cmp::max(self.length.load(AtomicOrdering::Relaxed), 0) as usize
+	}
+
+	/// Current sum of content length.
+	pub fn bytes(&self) -> usize {
+		std::cmp::max(self.bytes.load(AtomicOrdering::Relaxed), 0) as usize
+	}
+
+	/// Read-only clone of the interior.
+	pub fn clone(&self) -> ReadOnlyTrackedMap<K, V> {
+		ReadOnlyTrackedMap(self.index.clone())
+	}
+
+	/// Lock map for read.
+	pub fn read<'a>(&'a self) -> TrackedMapReadAccess<'a, K, V> {
+		TrackedMapReadAccess {
+			inner_guard: self.index.read(),
+		}
+	}
+
+	/// Lock map for write.
+	pub fn write<'a>(&'a self) -> TrackedMapWriteAccess<'a, K, V> {
+		TrackedMapWriteAccess {
+			inner_guard: self.index.write(),
+			bytes: &self.bytes,
+			length: &self.length,
+		}
+	}
+}
+
+/// Read-only access to map.
+///
+/// The only thing can be done is .read().
+pub struct ReadOnlyTrackedMap<K, V>(Arc<RwLock<HashMap<K, V>>>);
+
+impl<K, V> ReadOnlyTrackedMap<K, V>
+where
+	K: Eq + std::hash::Hash
+{
+	/// Lock map for read.
+	pub fn read<'a>(&'a self) -> TrackedMapReadAccess<'a, K, V> {
+		TrackedMapReadAccess {
+			inner_guard: self.0.read(),
+		}
+	}
+}
+
+pub struct TrackedMapReadAccess<'a, K, V> {
+	inner_guard: RwLockReadGuard<'a, HashMap<K, V>>,
+}
+
+impl<'a, K, V> TrackedMapReadAccess<'a, K, V>
+where
+	K: Eq + std::hash::Hash
+{
+	/// Returns true if map contains key.
+	pub fn contains_key(&self, key: &K) -> bool {
+		self.inner_guard.contains_key(key)
+	}
+
+	/// Returns reference to the contained value by key, if exists.
+	pub fn get(&self, key: &K) -> Option<&V> {
+		self.inner_guard.get(key)
+	}
+
+	/// Returns iterator over all values.
+	pub fn values(&self) -> std::collections::hash_map::Values<K, V> {
+		self.inner_guard.values()
+	}
+}
+
+pub struct TrackedMapWriteAccess<'a, K, V> {
+	bytes: &'a AtomicIsize,
+	length: &'a AtomicIsize,
+	inner_guard: RwLockWriteGuard<'a, HashMap<K, V>>,
+}
+
+impl<'a, K, V> TrackedMapWriteAccess<'a, K, V>
+where
+	K: Eq + std::hash::Hash, V: Size
+{
+	/// Insert value and return previous (if any).
+	pub fn insert(&mut self, key: K, val: V) -> Option<V> {
+		let new_bytes = val.size();
+		self.bytes.fetch_add(new_bytes as isize, AtomicOrdering::Relaxed);
+		self.length.fetch_add(1, AtomicOrdering::Relaxed);
+		self.inner_guard.insert(key, val).and_then(|old_val| {
+			self.bytes.fetch_sub(old_val.size() as isize, AtomicOrdering::Relaxed);
+			self.length.fetch_sub(1, AtomicOrdering::Relaxed);
+			Some(old_val)
+		})
+	}
+
+	/// Remove value by key.
+	pub fn remove(&mut self, key: &K) -> Option<V> {
+		let val = self.inner_guard.remove(key);
+		if let Some(size) = val.as_ref().map(Size::size) {
+			self.bytes.fetch_sub(size as isize, AtomicOrdering::Relaxed);
+			self.length.fetch_sub(1, AtomicOrdering::Relaxed);
+		}
+		val
+	}
+
+	/// Returns mutable reference to the contained value by key, if exists.
+	pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+		self.inner_guard.get_mut(key)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	impl Size for i32 {
+		fn size(&self) -> usize { *self as usize / 10 }
+	}
+
+	#[test]
+	fn basic() {
+		let map = TrackedMap::default();
+		map.write().insert(5, 10);
+		map.write().insert(6, 20);
+
+		assert_eq!(map.bytes(), 3);
+		assert_eq!(map.len(), 2);
+
+		map.write().insert(6, 30);
+
+		assert_eq!(map.bytes(), 4);
+		assert_eq!(map.len(), 2);
+
+		map.write().remove(&6);
+		assert_eq!(map.bytes(), 1);
+		assert_eq!(map.len(), 1);
+	}
+}

--- a/client/transaction-pool/graph/src/watcher.rs
+++ b/client/transaction-pool/graph/src/watcher.rs
@@ -1,33 +1,33 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Extrinsics status updates.
 
-use futures::{
-	Stream,
-	channel::mpsc,
-};
+use futures::Stream;
 use sp_transaction_pool::TransactionStatus;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedSender, TracingUnboundedReceiver};
 
 /// Extrinsic watcher.
 ///
 /// Represents a stream of status updates for particular extrinsic.
 #[derive(Debug)]
 pub struct Watcher<H, BH> {
-	receiver: mpsc::UnboundedReceiver<TransactionStatus<H, BH>>,
+	receiver: TracingUnboundedReceiver<TransactionStatus<H, BH>>,
 	hash: H,
 }
 
@@ -48,7 +48,7 @@ impl<H, BH> Watcher<H, BH> {
 /// Sender part of the watcher. Exposed only for testing purposes.
 #[derive(Debug)]
 pub struct Sender<H, BH> {
-	receivers: Vec<mpsc::UnboundedSender<TransactionStatus<H, BH>>>,
+	receivers: Vec<TracingUnboundedSender<TransactionStatus<H, BH>>>,
 	is_finalized: bool,
 }
 
@@ -64,7 +64,7 @@ impl<H, BH> Default for Sender<H, BH> {
 impl<H: Clone, BH: Clone> Sender<H, BH> {
 	/// Add a new watcher to this sender object.
 	pub fn new_watcher(&mut self, hash: H) -> Watcher<H, BH> {
-		let (tx, receiver) = mpsc::unbounded();
+		let (tx, receiver) = tracing_unbounded("mpsc_txpool_watcher");
 		self.receivers.push(tx);
 		Watcher {
 			receiver,

--- a/client/transaction-pool/src/api.rs
+++ b/client/transaction-pool/src/api.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Chain api required for the transaction pool.
 
@@ -23,9 +25,7 @@ use futures::{
 };
 
 use sc_client_api::{
-	blockchain::HeaderBackend,
-	light::{Fetcher, RemoteCallRequest, RemoteBodyRequest},
-	BlockBackend,
+	blockchain::HeaderBackend, light::{Fetcher, RemoteCallRequest, RemoteBodyRequest}, BlockBackend,
 };
 use sp_runtime::{
 	generic::BlockId, traits::{self, Block as BlockT, BlockIdTo, Header as HeaderT, Hash as HashT},
@@ -43,10 +43,7 @@ pub struct FullChainApi<Client, Block> {
 	_marker: PhantomData<Block>,
 }
 
-impl<Client, Block> FullChainApi<Client, Block> where
-	Block: BlockT,
-	Client: ProvideRuntimeApi<Block> + BlockIdTo<Block>,
-{
+impl<Client, Block> FullChainApi<Client, Block> {
 	/// Create new transaction pool logic.
 	pub fn new(client: Arc<Client>) -> Self {
 		FullChainApi {
@@ -56,22 +53,24 @@ impl<Client, Block> FullChainApi<Client, Block> where
 				.name_prefix("txpool-verifier")
 				.create()
 				.expect("Failed to spawn verifier threads, that are critical for node operation."),
-			_marker: Default::default()
+			_marker: Default::default(),
 		}
 	}
 }
 
-impl<Client, Block> sc_transaction_graph::ChainApi for FullChainApi<Client, Block> where
+impl<Client, Block> sc_transaction_graph::ChainApi for FullChainApi<Client, Block>
+where
 	Block: BlockT,
 	Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + BlockIdTo<Block>,
 	Client: Send + Sync + 'static,
 	Client::Api: TaggedTransactionQueue<Block>,
-	sp_api::ApiErrorFor<Client, Block>: Send,
+	sp_api::ApiErrorFor<Client, Block>: Send + std::fmt::Display,
 {
 	type Block = Block;
-	type Hash = Block::Hash;
 	type Error = error::Error;
-	type ValidationFuture = Pin<Box<dyn Future<Output = error::Result<TransactionValidity>> + Send>>;
+	type ValidationFuture = Pin<
+		Box<dyn Future<Output = error::Result<TransactionValidity>> + Send>
+	>;
 	type BodyFuture = Ready<error::Result<Option<Vec<<Self::Block as BlockT>::Extrinsic>>>>;
 
 	fn block_body(&self, id: &BlockId<Self::Block>) -> Self::BodyFuture {
@@ -88,24 +87,15 @@ impl<Client, Block> sc_transaction_graph::ChainApi for FullChainApi<Client, Bloc
 		let client = self.client.clone();
 		let at = at.clone();
 
-		self.pool.spawn_ok(futures_diagnose::diagnose("validate-transaction", async move {
-			let runtime_api = client.runtime_api();
-			let has_v2 = runtime_api
-				.has_api_with::<dyn TaggedTransactionQueue<Self::Block, Error=()>, _>(
-					&at, |v| v >= 2,
-				)
-				.unwrap_or_default();
-			let res = if has_v2 {
-				runtime_api.validate_transaction(&at, source, uxt)
-			} else {
-				#[allow(deprecated)] // old validate_transaction
-				runtime_api.validate_transaction_before_version_2(&at, uxt)
-			};
-			let res = res.map_err(|e| Error::RuntimeApi(format!("{:?}", e)));
-			if let Err(e) = tx.send(res) {
-				log::warn!("Unable to send a validate transaction result: {:?}", e);
-			}
-		}));
+		self.pool.spawn_ok(futures_diagnose::diagnose(
+			"validate-transaction",
+			async move {
+				let res = validate_transaction_blocking(&*client, &at, source, uxt);
+				if let Err(e) = tx.send(res) {
+					log::warn!("Unable to send a validate transaction result: {:?}", e);
+				}
+			},
+		));
 
 		Box::pin(async move {
 			match rx.await {
@@ -129,10 +119,69 @@ impl<Client, Block> sc_transaction_graph::ChainApi for FullChainApi<Client, Bloc
 		self.client.to_hash(at).map_err(|e| Error::BlockIdConversion(format!("{:?}", e)))
 	}
 
-	fn hash_and_length(&self, ex: &sc_transaction_graph::ExtrinsicFor<Self>) -> (Self::Hash, usize) {
+	fn hash_and_length(
+		&self,
+		ex: &sc_transaction_graph::ExtrinsicFor<Self>,
+	) -> (sc_transaction_graph::ExtrinsicHash<Self>, usize) {
 		ex.using_encoded(|x| {
 			(<traits::HashFor::<Block> as traits::Hash>::hash(x), x.len())
 		})
+	}
+}
+
+/// Helper function to validate a transaction using a full chain API.
+/// This method will call into the runtime to perform the validation.
+fn validate_transaction_blocking<Client, Block>(
+	client: &Client,
+	at: &BlockId<Block>,
+	source: TransactionSource,
+	uxt: sc_transaction_graph::ExtrinsicFor<FullChainApi<Client, Block>>,
+) -> error::Result<TransactionValidity>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + BlockIdTo<Block>,
+	Client: Send + Sync + 'static,
+	Client::Api: TaggedTransactionQueue<Block>,
+	sp_api::ApiErrorFor<Client, Block>: Send + std::fmt::Display,
+{
+	sp_tracing::enter_span!("validate_transaction");
+	let runtime_api = client.runtime_api();
+	let has_v2 = sp_tracing::tracing_span! { "check_version";
+		runtime_api
+			.has_api_with::<dyn TaggedTransactionQueue<Block, Error=()>, _>(&at, |v| v >= 2)
+			.unwrap_or_default()
+	};
+
+	sp_tracing::enter_span!("runtime::validate_transaction");
+	let res = if has_v2 {
+		runtime_api.validate_transaction(&at, source, uxt)
+	} else {
+		#[allow(deprecated)] // old validate_transaction
+		runtime_api.validate_transaction_before_version_2(&at, uxt)
+	};
+
+	res.map_err(|e| Error::RuntimeApi(e.to_string()))
+}
+
+impl<Client, Block> FullChainApi<Client, Block>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + BlockIdTo<Block>,
+	Client: Send + Sync + 'static,
+	Client::Api: TaggedTransactionQueue<Block>,
+	sp_api::ApiErrorFor<Client, Block>: Send + std::fmt::Display,
+{
+	/// Validates a transaction by calling into the runtime, same as
+	/// `validate_transaction` but blocks the current thread when performing
+	/// validation. Only implemented for `FullChainApi` since we can call into
+	/// the runtime locally.
+	pub fn validate_transaction_blocking(
+		&self,
+		at: &BlockId<Block>,
+		source: TransactionSource,
+		uxt: sc_transaction_graph::ExtrinsicFor<Self>,
+	) -> error::Result<TransactionValidity> {
+		validate_transaction_blocking(&*self.client, at, source, uxt)
 	}
 }
 
@@ -143,11 +192,7 @@ pub struct LightChainApi<Client, F, Block> {
 	_phantom: PhantomData<Block>,
 }
 
-impl<Client, F, Block> LightChainApi<Client, F, Block> where
-	Block: BlockT,
-	Client: HeaderBackend<Block>,
-	F: Fetcher<Block>,
-{
+impl<Client, F, Block> LightChainApi<Client, F, Block> {
 	/// Create new transaction pool logic.
 	pub fn new(client: Arc<Client>, fetcher: Arc<F>) -> Self {
 		LightChainApi {
@@ -158,16 +203,23 @@ impl<Client, F, Block> LightChainApi<Client, F, Block> where
 	}
 }
 
-impl<Client, F, Block> sc_transaction_graph::ChainApi for LightChainApi<Client, F, Block> where
-	Block: BlockT,
-	Client: HeaderBackend<Block> + 'static,
-	F: Fetcher<Block> + 'static,
+impl<Client, F, Block> sc_transaction_graph::ChainApi for
+	LightChainApi<Client, F, Block> where
+		Block: BlockT,
+		Client: HeaderBackend<Block> + 'static,
+		F: Fetcher<Block> + 'static,
 {
 	type Block = Block;
-	type Hash = Block::Hash;
 	type Error = error::Error;
-	type ValidationFuture = Box<dyn Future<Output = error::Result<TransactionValidity>> + Send + Unpin>;
-	type BodyFuture = Pin<Box<dyn Future<Output = error::Result<Option<Vec<<Self::Block as BlockT>::Extrinsic>>>> + Send>>;
+	type ValidationFuture = Box<
+		dyn Future<Output = error::Result<TransactionValidity>> + Send + Unpin
+	>;
+	type BodyFuture = Pin<
+		Box<
+			dyn Future<Output = error::Result<Option<Vec<<Self::Block as BlockT>::Extrinsic>>>>
+				+ Send
+		>
+	>;
 
 	fn validate_transaction(
 		&self,
@@ -204,15 +256,24 @@ impl<Client, F, Block> sc_transaction_graph::ChainApi for LightChainApi<Client, 
 		Box::new(remote_validation_request)
 	}
 
-	fn block_id_to_number(&self, at: &BlockId<Self::Block>) -> error::Result<Option<sc_transaction_graph::NumberFor<Self>>> {
+	fn block_id_to_number(
+		&self,
+		at: &BlockId<Self::Block>,
+	) -> error::Result<Option<sc_transaction_graph::NumberFor<Self>>> {
 		Ok(self.client.block_number_from_id(at)?)
 	}
 
-	fn block_id_to_hash(&self, at: &BlockId<Self::Block>) -> error::Result<Option<sc_transaction_graph::BlockHash<Self>>> {
+	fn block_id_to_hash(
+		&self,
+		at: &BlockId<Self::Block>,
+	) -> error::Result<Option<sc_transaction_graph::BlockHash<Self>>> {
 		Ok(self.client.block_hash_from_id(at)?)
 	}
 
-	fn hash_and_length(&self, ex: &sc_transaction_graph::ExtrinsicFor<Self>) -> (Self::Hash, usize) {
+	fn hash_and_length(
+		&self,
+		ex: &sc_transaction_graph::ExtrinsicFor<Self>,
+	) -> (sc_transaction_graph::ExtrinsicHash<Self>, usize) {
 		ex.using_encoded(|x| {
 			(<<Block::Header as HeaderT>::Hashing as HashT>::hash(x), x.len())
 		})

--- a/client/transaction-pool/src/error.rs
+++ b/client/transaction-pool/src/error.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Transaction pool error.
 

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -1,18 +1,20 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Substrate transaction pool implementation.
 
@@ -21,17 +23,19 @@
 #![warn(unused_extern_crates)]
 
 mod api;
-pub mod error;
 mod revalidation;
+mod metrics;
 
-#[cfg(any(feature = "test-helpers", test))]
+pub mod error;
+
+#[cfg(test)]
 pub mod testing;
 
 pub use sc_transaction_graph as txpool;
 pub use crate::api::{FullChainApi, LightChainApi};
 
-use std::{collections::HashMap, sync::Arc, pin::Pin};
-use futures::{Future, FutureExt, future::ready, channel::oneshot};
+use std::{collections::{HashMap, HashSet}, sync::Arc, pin::Pin};
+use futures::{prelude::*, future::{self, ready}, channel::oneshot};
 use parking_lot::Mutex;
 
 use sp_runtime::{
@@ -43,11 +47,19 @@ use sp_transaction_pool::{
 	TransactionStatusStreamFor, MaintainedTransactionPool, PoolFuture, ChainEvent,
 	TransactionSource,
 };
+use sc_transaction_graph::{ChainApi, ExtrinsicHash};
 use wasm_timer::Instant;
 
-type BoxedReadyIterator<Hash, Data> = Box<dyn Iterator<Item=Arc<sc_transaction_graph::base_pool::Transaction<Hash, Data>>> + Send>;
+use prometheus_endpoint::Registry as PrometheusRegistry;
+use crate::metrics::MetricsLink as PrometheusMetrics;
 
-type ReadyIteratorFor<PoolApi> = BoxedReadyIterator<sc_transaction_graph::ExHash<PoolApi>, sc_transaction_graph::ExtrinsicFor<PoolApi>>;
+type BoxedReadyIterator<Hash, Data> = Box<
+	dyn Iterator<Item=Arc<sc_transaction_graph::base_pool::Transaction<Hash, Data>>> + Send
+>;
+
+type ReadyIteratorFor<PoolApi> = BoxedReadyIterator<
+	sc_transaction_graph::ExtrinsicHash<PoolApi>, sc_transaction_graph::ExtrinsicFor<PoolApi>
+>;
 
 type PolledIterator<PoolApi> = Pin<Box<dyn Future<Output=ReadyIteratorFor<PoolApi>> + Send>>;
 
@@ -55,13 +67,14 @@ type PolledIterator<PoolApi> = Pin<Box<dyn Future<Output=ReadyIteratorFor<PoolAp
 pub struct BasicPool<PoolApi, Block>
 	where
 		Block: BlockT,
-		PoolApi: sc_transaction_graph::ChainApi<Block=Block, Hash=Block::Hash>,
+		PoolApi: ChainApi<Block=Block>,
 {
 	pool: Arc<sc_transaction_graph::Pool<PoolApi>>,
 	api: Arc<PoolApi>,
 	revalidation_strategy: Arc<Mutex<RevalidationStrategy<NumberFor<Block>>>>,
 	revalidation_queue: Arc<revalidation::RevalidationQueue<PoolApi>>,
 	ready_poll: Arc<Mutex<ReadyPoll<ReadyIteratorFor<PoolApi>, Block>>>,
+	metrics: PrometheusMetrics,
 }
 
 struct ReadyPoll<T, Block: BlockT> {
@@ -108,8 +121,7 @@ impl<T, Block: BlockT> ReadyPoll<T, Block> {
 #[cfg(not(target_os = "unknown"))]
 impl<PoolApi, Block> parity_util_mem::MallocSizeOf for BasicPool<PoolApi, Block>
 where
-	PoolApi: sc_transaction_graph::ChainApi<Block=Block, Hash=Block::Hash>,
-	PoolApi::Hash: parity_util_mem::MallocSizeOf,
+	PoolApi: ChainApi<Block=Block>,
 	Block: BlockT,
 {
 	fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
@@ -138,7 +150,7 @@ pub enum RevalidationType {
 impl<PoolApi, Block> BasicPool<PoolApi, Block>
 	where
 		Block: BlockT,
-		PoolApi: sc_transaction_graph::ChainApi<Block=Block, Hash=Block::Hash> + 'static,
+		PoolApi: ChainApi<Block=Block> + 'static,
 {
 	/// Create new basic transaction pool with provided api.
 	///
@@ -147,8 +159,31 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 	pub fn new(
 		options: sc_transaction_graph::Options,
 		pool_api: Arc<PoolApi>,
+		prometheus: Option<&PrometheusRegistry>,
 	) -> (Self, Option<Pin<Box<dyn Future<Output=()> + Send>>>) {
-		Self::with_revalidation_type(options, pool_api, RevalidationType::Full)
+		Self::with_revalidation_type(options, pool_api, prometheus, RevalidationType::Full)
+	}
+
+	/// Create new basic transaction pool with provided api, for tests.
+	#[cfg(test)]
+	pub fn new_test(
+		pool_api: Arc<PoolApi>,
+	) -> (Self, Pin<Box<dyn Future<Output=()> + Send>>, intervalier::BackSignalControl) {
+		let pool = Arc::new(sc_transaction_graph::Pool::new(Default::default(), pool_api.clone()));
+		let (revalidation_queue, background_task, notifier) =
+			revalidation::RevalidationQueue::new_test(pool_api.clone(), pool.clone());
+		(
+			BasicPool {
+				api: pool_api,
+				pool,
+				revalidation_queue: Arc::new(revalidation_queue),
+				revalidation_strategy: Arc::new(Mutex::new(RevalidationStrategy::Always)),
+				ready_poll: Default::default(),
+				metrics: Default::default(),
+			},
+			background_task,
+			notifier,
+		)
 	}
 
 	/// Create new basic transaction pool with provided api and custom
@@ -156,6 +191,7 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 	pub fn with_revalidation_type(
 		options: sc_transaction_graph::Options,
 		pool_api: Arc<PoolApi>,
+		prometheus: Option<&PrometheusRegistry>,
 		revalidation_type: RevalidationType,
 	) -> (Self, Option<Pin<Box<dyn Future<Output=()> + Send>>>) {
 		let pool = Arc::new(sc_transaction_graph::Pool::new(options, pool_api.clone()));
@@ -166,6 +202,7 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 				(queue, Some(background))
 			},
 		};
+
 		(
 			BasicPool {
 				api: pool_api,
@@ -178,6 +215,7 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 					}
 				)),
 				ready_poll: Default::default(),
+				metrics: PrometheusMetrics::new(prometheus),
 			},
 			background_task,
 		)
@@ -192,11 +230,13 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 	where
 		Block: BlockT,
-		PoolApi: 'static + sc_transaction_graph::ChainApi<Block=Block, Hash=Block::Hash>,
+		PoolApi: 'static + ChainApi<Block=Block>,
 {
 	type Block = PoolApi::Block;
-	type Hash = sc_transaction_graph::ExHash<PoolApi>;
-	type InPoolTransaction = sc_transaction_graph::base_pool::Transaction<TxHash<Self>, TransactionFor<Self>>;
+	type Hash = sc_transaction_graph::ExtrinsicHash<PoolApi>;
+	type InPoolTransaction = sc_transaction_graph::base_pool::Transaction<
+		TxHash<Self>, TransactionFor<Self>
+	>;
 	type Error = PoolApi::Error;
 
 	fn submit_at(
@@ -207,8 +247,15 @@ impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 	) -> PoolFuture<Vec<Result<TxHash<Self>, Self::Error>>, Self::Error> {
 		let pool = self.pool.clone();
 		let at = *at;
+
+		self.metrics.report(|metrics| metrics.validations_scheduled.inc_by(xts.len() as u64));
+
+		let metrics = self.metrics.clone();
 		async move {
-			pool.submit_at(&at, source, xts, false).await
+			let tx_count = xts.len();
+			let res = pool.submit_at(&at, source, xts, false).await;
+			metrics.report(|metrics| metrics.validations_finished.inc_by(tx_count as u64));
+			res
 		}.boxed()
 	}
 
@@ -220,8 +267,16 @@ impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 	) -> PoolFuture<TxHash<Self>, Self::Error> {
 		let pool = self.pool.clone();
 		let at = *at;
+
+		self.metrics.report(|metrics| metrics.validations_scheduled.inc());
+
+		let metrics = self.metrics.clone();
 		async move {
-			pool.submit_one(&at, source, xt).await
+			let res = pool.submit_one(&at, source, xt).await;
+
+			metrics.report(|metrics| metrics.validations_finished.inc());
+			res
+
 		}.boxed()
 	}
 
@@ -234,15 +289,24 @@ impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 		let at = *at;
 		let pool = self.pool.clone();
 
+		self.metrics.report(|metrics| metrics.validations_scheduled.inc());
+
+		let metrics = self.metrics.clone();
 		async move {
-			pool.submit_and_watch(&at, source, xt)
+			let result = pool.submit_and_watch(&at, source, xt)
 				.map(|result| result.map(|watcher| Box::new(watcher.into_stream()) as _))
-				.await
+				.await;
+
+			metrics.report(|metrics| metrics.validations_finished.inc());
+
+			result
 		}.boxed()
 	}
 
 	fn remove_invalid(&self, hashes: &[TxHash<Self>]) -> Vec<Arc<Self::InPoolTransaction>> {
-		self.pool.validated_pool().remove_invalid(hashes)
+		let removed = self.pool.validated_pool().remove_invalid(hashes);
+		self.metrics.report(|metrics| metrics.validations_invalid.inc_by(removed.len() as u64));
+		removed
 	}
 
 	fn status(&self) -> PoolStatus {
@@ -267,6 +331,7 @@ impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 
 	fn ready_at(&self, at: NumberFor<Self::Block>) -> PolledIterator<PoolApi> {
 		if self.ready_poll.lock().updated_at() >= at {
+			log::trace!(target: "txpool", "Transaction pool already processed block  #{}", at);
 			let iterator: ReadyIteratorFor<PoolApi> = Box::new(self.pool.validated_pool().ready());
 			return Box::pin(futures::future::ready(iterator));
 		}
@@ -371,22 +436,51 @@ impl<N: Clone + Copy + AtLeast32Bit> RevalidationStatus<N> {
 	}
 }
 
+/// Prune the known txs for the given block.
+async fn prune_known_txs_for_block<Block: BlockT, Api: ChainApi<Block = Block>>(
+	block_id: BlockId<Block>,
+	api: &Api,
+	pool: &sc_transaction_graph::Pool<Api>,
+) -> Vec<ExtrinsicHash<Api>> {
+	let hashes = api.block_body(&block_id).await
+		.unwrap_or_else(|e| {
+			log::warn!("Prune known transactions: error request {:?}!", e);
+			None
+		})
+		.unwrap_or_default()
+		.into_iter()
+		.map(|tx| pool.hash_of(&tx))
+		.collect::<Vec<_>>();
+
+	log::trace!(target: "txpool", "Pruning transactions: {:?}", hashes);
+
+	if let Err(e) = pool.prune_known(&block_id, &hashes) {
+		log::error!("Cannot prune known in the pool {:?}!", e);
+	}
+
+	hashes
+}
+
 impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 	where
 		Block: BlockT,
-		PoolApi: 'static + sc_transaction_graph::ChainApi<Block=Block, Hash=Block::Hash>,
+		PoolApi: 'static + ChainApi<Block=Block>,
 {
 	fn maintain(&self, event: ChainEvent<Self::Block>) -> Pin<Box<dyn Future<Output=()> + Send>> {
 		match event {
-			ChainEvent::NewBlock { id, retracted, .. } => {
-				let id = id.clone();
+			ChainEvent::NewBlock { hash, tree_route, is_new_best, .. } => {
 				let pool = self.pool.clone();
 				let api = self.api.clone();
 
+				let id = BlockId::hash(hash);
 				let block_number = match api.block_id_to_number(&id) {
 					Ok(Some(number)) => number,
 					_ => {
-						log::trace!(target: "txpool", "Skipping chain event - no number for that block {:?}", id);
+						log::trace!(
+							target: "txpool",
+							"Skipping chain event - no number for that block {:?}",
+							id,
+						);
 						return Box::pin(ready(()));
 					}
 				};
@@ -397,40 +491,59 @@ impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 					Some(20.into()),
 				);
 				let revalidation_strategy = self.revalidation_strategy.clone();
-				let retracted = retracted.clone();
 				let revalidation_queue = self.revalidation_queue.clone();
 				let ready_poll = self.ready_poll.clone();
+				let metrics = self.metrics.clone();
 
 				async move {
-					// We don't query block if we won't prune anything
-					if !pool.validated_pool().status().is_empty() {
-						let hashes = api.block_body(&id).await
-							.unwrap_or_else(|e| {
-								log::warn!("Prune known transactions: error request {:?}!", e);
-								None
-							})
-							.unwrap_or_default()
-							.into_iter()
-							.map(|tx| pool.hash_of(&tx))
-							.collect::<Vec<_>>();
+					// We keep track of everything we prune so that later we won't add
+					// tranactions with those hashes from the retracted blocks.
+					let mut pruned_log = HashSet::<ExtrinsicHash<PoolApi>>::new();
 
-						if let Err(e) = pool.prune_known(&id, &hashes) {
-							log::error!("Cannot prune known in the pool {:?}!", e);
+					// If there is a tree route, we use this to prune known tx based on the enacted
+					// blocks. Before pruning enacted transactions, we inform the listeners about
+					// retracted blocks and their transactions. This order is important, because
+					// if we enact and retract the same transaction at the same time, we want to
+					// send first the retract and than the prune event.
+					if let Some(ref tree_route) = tree_route {
+						for retracted in tree_route.retracted() {
+							// notify txs awaiting finality that it has been retracted
+							pool.validated_pool().on_block_retracted(retracted.hash.clone());
 						}
+
+						future::join_all(
+							tree_route
+								.enacted()
+								.iter()
+								.map(|h|
+									prune_known_txs_for_block(
+										BlockId::Hash(h.hash.clone()),
+										&*api,
+										&*pool,
+									),
+								),
+						).await.into_iter().for_each(|enacted_log|{
+							pruned_log.extend(enacted_log);
+						})
 					}
 
-					let extra_pool = pool.clone();
-					// After #5200 lands, this arguably might be moved to the handler of "all blocks notification".
-					ready_poll.lock().trigger(block_number, move || Box::new(extra_pool.validated_pool().ready()));
+					// If this is a new best block, we need to prune its transactions from the pool.
+					if is_new_best {
+						pruned_log.extend(prune_known_txs_for_block(id.clone(), &*api, &*pool).await);
+					}
 
-					if next_action.resubmit {
+					metrics.report(
+						|metrics| metrics.block_transactions_pruned.inc_by(pruned_log.len() as u64)
+					);
+
+					if let (true, Some(tree_route)) = (next_action.resubmit, tree_route) {
 						let mut resubmit_transactions = Vec::new();
 
-						for retracted_hash in retracted {
-							// notify txs awaiting finality that it has been retracted
-							pool.validated_pool().on_block_retracted(retracted_hash.clone());
+						for retracted in tree_route.retracted() {
+							let hash = retracted.hash.clone();
 
-							let block_transactions = api.block_body(&BlockId::hash(retracted_hash.clone())).await
+							let block_transactions = api.block_body(&BlockId::hash(hash))
+								.await
 								.unwrap_or_else(|e| {
 									log::warn!("Failed to fetch block body {:?}!", e);
 									None
@@ -439,25 +552,63 @@ impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 								.into_iter()
 								.filter(|tx| tx.is_signed().unwrap_or(true));
 
-							resubmit_transactions.extend(block_transactions);
+							let mut resubmitted_to_report = 0;
+
+							resubmit_transactions.extend(
+								block_transactions.into_iter().filter(|tx| {
+									let tx_hash = pool.hash_of(&tx);
+									let contains = pruned_log.contains(&tx_hash);
+
+									// need to count all transactions, not just filtered, here
+									resubmitted_to_report += 1;
+
+									if !contains {
+										log::debug!(
+											target: "txpool",
+											"[{:?}]: Resubmitting from retracted block {:?}",
+											tx_hash,
+											hash,
+										);
+									}
+									!contains
+								})
+							);
+
+							metrics.report(
+								|metrics| metrics.block_transactions_resubmitted.inc_by(resubmitted_to_report)
+							);
 						}
+
 						if let Err(e) = pool.submit_at(
 							&id,
 							// These transactions are coming from retracted blocks, we should
 							// simply consider them external.
 							TransactionSource::External,
 							resubmit_transactions,
-							true
+							true,
 						).await {
 							log::debug!(
 								target: "txpool",
-								"[{:?}] Error re-submitting transactions: {:?}", id, e
+								"[{:?}] Error re-submitting transactions: {:?}",
+								id,
+								e,
 							)
 						}
 					}
 
+					let extra_pool = pool.clone();
+					// After #5200 lands, this arguably might be moved to the
+					// handler of "all blocks notification".
+					ready_poll.lock().trigger(
+						block_number,
+						move || Box::new(extra_pool.validated_pool().ready()),
+					);
+
 					if next_action.revalidate {
-						let hashes = pool.validated_pool().ready().map(|tx| tx.hash.clone()).collect();
+						let hashes = pool.validated_pool()
+							.ready()
+							.map(|tx| tx.hash.clone())
+							.collect();
 						revalidation_queue.revalidate_later(block_number, hashes).await;
 					}
 
@@ -478,4 +629,24 @@ impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 			}
 		}
 	}
+}
+
+/// Inform the transaction pool about imported and finalized blocks.
+pub async fn notification_future<Client, Pool, Block>(
+	client: Arc<Client>,
+	txpool: Arc<Pool>
+)
+	where
+		Block: BlockT,
+		Client: sc_client_api::BlockchainEvents<Block>,
+		Pool: MaintainedTransactionPool<Block=Block>,
+{
+	let import_stream = client.import_notification_stream().map(Into::into).fuse();
+	let finality_stream = client.finality_notification_stream()
+		.map(Into::into)
+		.fuse();
+
+	futures::stream::select(import_stream, finality_stream)
+		.for_each(|evt| txpool.maintain(evt))
+		.await
 }

--- a/client/transaction-pool/src/metrics.rs
+++ b/client/transaction-pool/src/metrics.rs
@@ -1,0 +1,95 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Transaction pool Prometheus metrics.
+
+use std::sync::Arc;
+
+use prometheus_endpoint::{register, Counter, PrometheusError, Registry, U64};
+
+#[derive(Clone, Default)]
+pub struct MetricsLink(Arc<Option<Metrics>>);
+
+impl MetricsLink {
+	pub fn new(registry: Option<&Registry>) -> Self {
+		Self(Arc::new(
+			registry.and_then(|registry|
+				Metrics::register(registry)
+					.map_err(|err| { log::warn!("Failed to register prometheus metrics: {}", err); })
+					.ok()
+			)
+		))
+	}
+
+	pub fn report(&self, do_this: impl FnOnce(&Metrics)) {
+		if let Some(metrics) = self.0.as_ref() {
+			do_this(metrics);
+		}
+	}
+}
+
+/// Transaction pool Prometheus metrics.
+pub struct Metrics {
+	pub validations_scheduled: Counter<U64>,
+	pub validations_finished: Counter<U64>,
+	pub validations_invalid: Counter<U64>,
+	pub block_transactions_pruned: Counter<U64>,
+	pub block_transactions_resubmitted: Counter<U64>,
+}
+
+impl Metrics {
+	pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			validations_scheduled: register(
+				Counter::new(
+					"sub_txpool_validations_scheduled",
+					"Total number of transactions scheduled for validation",
+				)?,
+				registry,
+			)?,
+			validations_finished: register(
+				Counter::new(
+					"sub_txpool_validations_finished",
+					"Total number of transactions that finished validation",
+				)?,
+				registry,
+			)?,
+			validations_invalid: register(
+				Counter::new(
+					"sub_txpool_validations_invalid",
+					"Total number of transactions that were removed from the pool as invalid",
+				)?,
+				registry,
+			)?,
+			block_transactions_pruned: register(
+				Counter::new(
+					"sub_txpool_block_transactions_pruned",
+					"Total number of transactions that was requested to be pruned by block events",
+				)?,
+				registry,
+			)?,
+			block_transactions_resubmitted: register(
+				Counter::new(
+					"sub_txpool_block_transactions_resubmitted",
+					"Total number of transactions that was requested to be resubmitted by block events",
+				)?,
+				registry,
+			)?,
+		})
+	}
+}

--- a/client/transaction-pool/src/revalidation.rs
+++ b/client/transaction-pool/src/revalidation.rs
@@ -1,43 +1,45 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Pool periodic revalidation.
 
 use std::{sync::Arc, pin::Pin, collections::{HashMap, HashSet, BTreeMap}};
 
-use sc_transaction_graph::{ChainApi, Pool, ExHash, NumberFor, ValidatedTransaction};
+use sc_transaction_graph::{ChainApi, Pool, ExtrinsicHash, NumberFor, ValidatedTransaction};
 use sp_runtime::traits::{Zero, SaturatedConversion};
 use sp_runtime::generic::BlockId;
 use sp_runtime::transaction_validity::TransactionValidityError;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedSender, TracingUnboundedReceiver};
 
-use futures::{prelude::*, channel::mpsc, stream::unfold};
+use futures::prelude::*;
 use std::time::Duration;
-use futures_timer::Delay;
 
 #[cfg(not(test))]
 const BACKGROUND_REVALIDATION_INTERVAL: Duration = Duration::from_millis(200);
 #[cfg(test)]
-pub const BACKGROUND_REVALIDATION_INTERVAL: Duration = Duration::from_millis(5);
+pub const BACKGROUND_REVALIDATION_INTERVAL: Duration = Duration::from_millis(1);
 
-const BACKGROUND_REVALIDATION_BATCH_SIZE: usize = 20;
+const MIN_BACKGROUND_REVALIDATION_BATCH_SIZE: usize = 20;
 
 /// Payload from queue to worker.
 struct WorkerPayload<Api: ChainApi> {
 	at: NumberFor<Api>,
-	transactions: Vec<ExHash<Api>>,
+	transactions: Vec<ExtrinsicHash<Api>>,
 }
 
 /// Async revalidation worker.
@@ -47,17 +49,11 @@ struct RevalidationWorker<Api: ChainApi> {
 	api: Arc<Api>,
 	pool: Arc<Pool<Api>>,
 	best_block: NumberFor<Api>,
-	block_ordered: BTreeMap<NumberFor<Api>, HashSet<ExHash<Api>>>,
-	members: HashMap<ExHash<Api>, NumberFor<Api>>,
+	block_ordered: BTreeMap<NumberFor<Api>, HashSet<ExtrinsicHash<Api>>>,
+	members: HashMap<ExtrinsicHash<Api>, NumberFor<Api>>,
 }
 
 impl<Api: ChainApi> Unpin for RevalidationWorker<Api> {}
-
-fn interval(duration: Duration) -> impl Stream<Item=()> + Unpin {
-	unfold((), move |_| {
-		Delay::new(duration).map(|_| Some(((), ())))
-	}).map(drop)
-}
 
 /// Revalidate batch of transaction.
 ///
@@ -67,18 +63,22 @@ async fn batch_revalidate<Api: ChainApi>(
 	pool: Arc<Pool<Api>>,
 	api: Arc<Api>,
 	at: NumberFor<Api>,
-	batch: impl IntoIterator<Item=ExHash<Api>>,
+	batch: impl IntoIterator<Item=ExtrinsicHash<Api>>,
 ) {
 	let mut invalid_hashes = Vec::new();
 	let mut revalidated = HashMap::new();
 
-	for ext_hash in batch {
-		let ext = match pool.validated_pool().ready_by_hash(&ext_hash) {
-			Some(ext) => ext,
-			None => continue,
-		};
+	let validation_results = futures::future::join_all(
+		batch.into_iter().filter_map(|ext_hash| {
+			pool.validated_pool().ready_by_hash(&ext_hash).map(|ext| {
+				api.validate_transaction(&BlockId::Number(at), ext.source, ext.data.clone())
+					.map(move |validation_result| (validation_result, ext_hash, ext))
+			})
+		})
+	).await;
 
-		match api.validate_transaction(&BlockId::Number(at), ext.source, ext.data.clone()).await {
+	for (validation_result, ext_hash, ext) in validation_results {
+		match validation_result {
 			Ok(Err(TransactionValidityError::Invalid(err))) => {
 				log::debug!(target: "txpool", "[{:?}]: Revalidation: invalid {:?}", ext_hash, err);
 				invalid_hashes.push(ext_hash);
@@ -133,9 +133,9 @@ impl<Api: ChainApi> RevalidationWorker<Api> {
 		}
 	}
 
-	fn prepare_batch(&mut self) -> Vec<ExHash<Api>> {
+	fn prepare_batch(&mut self) -> Vec<ExtrinsicHash<Api>> {
 		let mut queued_exts = Vec::new();
-		let mut left = BACKGROUND_REVALIDATION_BATCH_SIZE;
+		let mut left = std::cmp::max(MIN_BACKGROUND_REVALIDATION_BATCH_SIZE, self.members.len() / 4);
 
 		// Take maximum of count transaction by order
 		// which they got into the pool
@@ -182,7 +182,7 @@ impl<Api: ChainApi> RevalidationWorker<Api> {
 		for ext_hash in transactions {
 			// we don't add something that already scheduled for revalidation
 			if self.members.contains_key(&ext_hash) {
-				log::debug!(
+				log::trace!(
 					target: "txpool",
 					"[{:?}] Skipped adding for revalidation: Already there.",
 					ext_hash,
@@ -207,19 +207,33 @@ impl<Api: ChainApi> RevalidationWorker<Api> {
 	/// It does two things: periodically tries to process some transactions
 	/// from the queue and also accepts messages to enqueue some more
 	/// transactions from the pool.
-	pub async fn run(mut self, from_queue: mpsc::UnboundedReceiver<WorkerPayload<Api>>) {
-		let interval = interval(BACKGROUND_REVALIDATION_INTERVAL).fuse();
+	pub async fn run<R: intervalier::IntoStream>(
+		mut self,
+		from_queue: TracingUnboundedReceiver<WorkerPayload<Api>>,
+		interval: R,
+	) where R: Send, R::Guard: Send
+	{
+		let interval = interval.into_stream().fuse();
 		let from_queue = from_queue.fuse();
 		futures::pin_mut!(interval, from_queue);
 		let this = &mut self;
 
 		loop {
 			futures::select! {
-				_ = interval.next() => {
+				_guard = interval.next() => {
 					let next_batch = this.prepare_batch();
 					let batch_len = next_batch.len();
 
 					batch_revalidate(this.pool.clone(), this.api.clone(), this.best_block, next_batch).await;
+
+					#[cfg(test)]
+					{
+						use intervalier::Guard;
+						// only trigger test events if something was processed
+						if batch_len == 0 {
+							_guard.expect("Always some() in tests").skip();
+						}
+					}
 
 					if batch_len > 0 || this.len() > 0 {
 						log::debug!(
@@ -235,6 +249,16 @@ impl<Api: ChainApi> RevalidationWorker<Api> {
 						Some(worker_payload) => {
 							this.best_block = worker_payload.at;
 							this.push(worker_payload);
+
+							if this.members.len() > 0 {
+								log::debug!(
+									target: "txpool",
+									"Updated revalidation queue at {}. Transactions: {:?}",
+									this.best_block,
+									this.members,
+								);
+							}
+
 							continue;
 						},
 						// R.I.P. worker!
@@ -254,7 +278,7 @@ impl<Api: ChainApi> RevalidationWorker<Api> {
 pub struct RevalidationQueue<Api: ChainApi> {
 	pool: Arc<Pool<Api>>,
 	api: Arc<Api>,
-	background: Option<mpsc::UnboundedSender<WorkerPayload<Api>>>,
+	background: Option<TracingUnboundedSender<WorkerPayload<Api>>>,
 }
 
 impl<Api: ChainApi> RevalidationQueue<Api>
@@ -270,11 +294,14 @@ where
 		}
 	}
 
-	/// New revalidation queue with background worker.
-	pub fn new_background(api: Arc<Api>, pool: Arc<Pool<Api>>) ->
-		(Self, Pin<Box<dyn Future<Output=()> + Send>>)
+	pub fn new_with_interval<R: intervalier::IntoStream>(
+		api: Arc<Api>,
+		pool: Arc<Pool<Api>>,
+		interval: R,
+	) -> (Self, Pin<Box<dyn Future<Output=()> + Send>>)
+	where R: Send + 'static, R::Guard: Send
 	{
-		let (to_worker, from_queue) = mpsc::unbounded();
+		let (to_worker, from_queue) = tracing_unbounded("mpsc_revalidation_queue");
 
 		let worker = RevalidationWorker::new(api.clone(), pool.clone());
 
@@ -285,7 +312,25 @@ where
 				background: Some(to_worker),
 			};
 
-		(queue, worker.run(from_queue).boxed())
+		(queue, worker.run(from_queue, interval).boxed())
+	}
+
+	/// New revalidation queue with background worker.
+	pub fn new_background(api: Arc<Api>, pool: Arc<Pool<Api>>) ->
+		(Self, Pin<Box<dyn Future<Output=()> + Send>>)
+	{
+		Self::new_with_interval(api, pool, intervalier::Interval::new(BACKGROUND_REVALIDATION_INTERVAL))
+	}
+
+	/// New revalidation queue with background worker and test signal.
+	#[cfg(test)]
+	pub fn new_test(api: Arc<Api>, pool: Arc<Pool<Api>>) ->
+		(Self, Pin<Box<dyn Future<Output=()> + Send>>, intervalier::BackSignalControl)
+	{
+		let (interval, notifier) = intervalier::BackSignalInterval::new(BACKGROUND_REVALIDATION_INTERVAL);
+		let (queue, background) = Self::new_with_interval(api, pool, interval);
+
+		(queue, background, notifier)
 	}
 
 	/// Queue some transaction for later revalidation.
@@ -293,9 +338,9 @@ where
 	/// If queue configured with background worker, this will return immediately.
 	/// If queue configured without background worker, this will resolve after
 	/// revalidation is actually done.
-	pub async fn revalidate_later(&self, at: NumberFor<Api>, transactions: Vec<ExHash<Api>>) {
+	pub async fn revalidate_later(&self, at: NumberFor<Api>, transactions: Vec<ExtrinsicHash<Api>>) {
 		if transactions.len() > 0 {
-			log::debug!(target: "txpool", "Added {} transactions to revalidation queue", transactions.len());
+			log::debug!(target: "txpool", "Sent {} transactions to revalidation queue", transactions.len());
 		}
 
 		if let Some(ref to_worker) = self.background {
@@ -318,9 +363,7 @@ mod tests {
 	use sp_transaction_pool::TransactionSource;
 	use substrate_test_runtime_transaction_pool::{TestApi, uxt};
 	use futures::executor::block_on;
-	use substrate_test_runtime_client::{
-		AccountKeyring::*,
-	};
+	use substrate_test_runtime_client::AccountKeyring::*;
 
 	fn setup() -> (Arc<TestApi>, Pool<TestApi>) {
 		let test_api = Arc::new(TestApi::empty());

--- a/client/transaction-pool/src/testing/mod.rs
+++ b/client/transaction-pool/src/testing/mod.rs
@@ -1,18 +1,20 @@
-// Copyright 2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Tests for top-level transaction pool api
 

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sp-tracing"
+version = "2.0.0-rc3"
+license = "Apache-2.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "Instrumentation primitives and macros for Substrate."
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+tracing = { version = "0.1.13", optional = true }
+
+[features]
+default = [ "std" ]
+std = [ "tracing" ]

--- a/primitives/tracing/src/lib.rs
+++ b/primitives/tracing/src/lib.rs
@@ -1,0 +1,85 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Substrate tracing primitives and macros.
+//!
+//! To trace functions or invidual code in Substrate, this crate provides [`tracing_span`]
+//! and [`enter_span`]. See the individual docs for how to use these macros.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub use tracing;
+
+/// Runs given code within a tracing span, measuring it's execution time.
+///
+/// If tracing is not enabled, the code is still executed.
+///
+/// # Example
+///
+/// ```
+/// sp_tracing::tracing_span! {
+///     "test-span";
+///     1 + 1;
+///     // some other complex code
+/// }
+/// ```
+#[macro_export]
+macro_rules! tracing_span {
+	(
+		$name:expr;
+		$( $code:tt )*
+	) => {
+		{
+			$crate::enter_span!($name);
+			$( $code )*
+		}
+	}
+}
+
+/// Enter a span.
+///
+/// The span will be valid, until the scope is left.
+///
+/// # Example
+///
+/// ```
+/// sp_tracing::enter_span!("test-span");
+/// ```
+#[macro_export]
+macro_rules! enter_span {
+	( $name:expr ) => {
+		let __tracing_span__ = $crate::if_tracing!(
+			$crate::tracing::span!($crate::tracing::Level::TRACE, $name)
+		);
+		let __tracing_guard__ = $crate::if_tracing!(__tracing_span__.enter());
+	}
+}
+
+/// Generates the given code if the tracing dependency is enabled.
+#[macro_export]
+#[cfg(feature = "std")]
+macro_rules! if_tracing {
+	( $if:expr ) => {{ $if }}
+}
+
+#[macro_export]
+#[cfg(not(feature = "std"))]
+macro_rules! if_tracing {
+	( $if:expr ) => {{}}
+}

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "sp-transaction-pool"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-license = "GPL-3.0"
+license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Transaction pool primitives types & Runtime API."
 documentation = "https://docs.rs/sp-transaction-pool"
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", optional = true }
@@ -17,7 +19,9 @@ futures = { version = "0.3.1", optional = true }
 log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.101", features = ["derive"], optional = true}
 sp-api = { version = "2.0.0-alpha.5", default-features = false, path = "../api" }
+sp-blockchain = { version = "2.0.0-alpha.5", optional = true, path = "../blockchain" }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false, path = "../runtime" }
+sp-utils = { version = "2.0.0-rc3", default-features = false, path = "../utils" }
 
 [features]
 default = [ "std" ]
@@ -28,5 +32,6 @@ std = [
 	"log",
 	"serde",
 	"sp-api/std",
+	"sp-blockchain",
 	"sp-runtime/std",
 ]

--- a/primitives/transaction-pool/src/error.rs
+++ b/primitives/transaction-pool/src/error.rs
@@ -1,18 +1,19 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Transaction pool errors.
 

--- a/primitives/transaction-pool/src/pool.rs
+++ b/primitives/transaction-pool/src/pool.rs
@@ -1,18 +1,19 @@
-// Copyright 2019-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Transaction pool primitives types & Runtime API.
 
@@ -22,11 +23,9 @@ use std::{
 	sync::Arc,
 	pin::Pin,
 };
-use futures::{
-	Future, Stream,
-	channel::mpsc,
-};
+use futures::{Future, Stream,};
 use serde::{Deserialize, Serialize};
+use sp_utils::mpsc;
 use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, Member, NumberFor},
@@ -132,7 +131,7 @@ pub enum TransactionStatus<Hash, BlockHash> {
 pub type TransactionStatusStream<Hash, BlockHash> = dyn Stream<Item=TransactionStatus<Hash, BlockHash>> + Send + Unpin;
 
 /// The import notification event stream.
-pub type ImportNotificationStream<H> = mpsc::UnboundedReceiver<H>;
+pub type ImportNotificationStream<H> = mpsc::TracingUnboundedReceiver<H>;
 
 /// Transaction hash type for a pool.
 pub type TxHash<P> = <P as TransactionPool>::Hash;
@@ -252,12 +251,14 @@ pub enum ChainEvent<B: BlockT> {
 	NewBlock {
 		/// Is this the new best block.
 		is_new_best: bool,
-		/// Id of the just imported block.
-		id: BlockId<B>,
+		/// Hash of the block.
+		hash: B::Hash,
 		/// Header of the just imported block
 		header: B::Header,
-		/// List of retracted blocks ordered by block number.
-		retracted: Vec<B::Hash>,
+		/// Tree route from old best to new best parent that was calculated on import.
+		///
+		/// If `None`, no re-org happened on import.
+		tree_route: Option<Arc<sp_blockchain::TreeRoute<B>>>,
 	},
 	/// An existing block has been finalized.
 	Finalized {

--- a/primitives/transaction-pool/src/runtime_api.rs
+++ b/primitives/transaction-pool/src/runtime_api.rs
@@ -1,18 +1,19 @@
-// Copyright 2019-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Tagged Transaction Queue Runtime API.
 

--- a/primitives/utils/Cargo.toml
+++ b/primitives/utils/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sp-utils"
+version = "2.0.0-rc3"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "I/O for Substrate runtimes"
+
+[dependencies]
+futures = "0.3.4"
+futures-core = "0.3.4"
+lazy_static = "1.4.0"
+prometheus = "0.8.0"
+
+[features]
+default = ["metered"]
+metered = []

--- a/primitives/utils/src/lib.rs
+++ b/primitives/utils/src/lib.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,20 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Transaction pool primitives types & Runtime API.
+//! Utilities Primitives for Substrate
 
-#![warn(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
-
-pub mod runtime_api;
-#[cfg(feature = "std")]
-pub mod error;
-#[cfg(feature = "std")]
-mod pool;
-
-#[cfg(feature = "std")]
-pub use pool::*;
-
-pub use sp_runtime::transaction_validity::{
-	TransactionLongevity, TransactionPriority, TransactionTag, TransactionSource,
-};
+pub mod metrics;
+pub mod mpsc;

--- a/primitives/utils/src/metrics.rs
+++ b/primitives/utils/src/metrics.rs
@@ -1,0 +1,59 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Metering primitives and globals
+
+use lazy_static::lazy_static;
+use prometheus::{
+	Registry, Error as PrometheusError,
+	core::{ AtomicU64, GenericGauge, GenericCounter },
+};
+
+#[cfg(feature = "metered")]
+use prometheus::{core::GenericCounterVec, Opts};
+
+
+lazy_static! {
+	pub static ref TOKIO_THREADS_TOTAL: GenericCounter<AtomicU64> = GenericCounter::new(
+		"tokio_threads_total", "Total number of threads created"
+	).expect("Creating of statics doesn't fail. qed");
+
+	pub static ref TOKIO_THREADS_ALIVE: GenericGauge<AtomicU64> = GenericGauge::new(
+		"tokio_threads_alive", "Number of threads alive right now"
+	).expect("Creating of statics doesn't fail. qed");
+}
+
+#[cfg(feature = "metered")]
+lazy_static! {
+	pub static ref UNBOUNDED_CHANNELS_COUNTER : GenericCounterVec<AtomicU64> = GenericCounterVec::new(
+		Opts::new("unbounded_channel_len", "Items in each mpsc::unbounded instance"),
+		&["entity", "action"] // 'name of channel, send|received|dropped
+	).expect("Creating of statics doesn't fail. qed");
+
+}
+
+
+/// Register the statics to report to registry
+pub fn register_globals(registry: &Registry) -> Result<(), PrometheusError> {
+	registry.register(Box::new(TOKIO_THREADS_ALIVE.clone()))?;
+	registry.register(Box::new(TOKIO_THREADS_TOTAL.clone()))?;
+
+	#[cfg(feature = "metered")]
+	registry.register(Box::new(UNBOUNDED_CHANNELS_COUNTER.clone()))?;
+
+	Ok(())
+}

--- a/primitives/utils/src/mpsc.rs
+++ b/primitives/utils/src/mpsc.rs
@@ -1,0 +1,251 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Features to meter unbounded channels
+
+#[cfg(not(feature = "metered"))]
+mod inner {
+	// just aliased, non performance implications
+	use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+	pub type TracingUnboundedSender<T> = UnboundedSender<T>;
+	pub type TracingUnboundedReceiver<T> = UnboundedReceiver<T>;
+
+	/// Alias `mpsc::unbounded`
+	pub fn tracing_unbounded<T>(_key: &'static str) ->(TracingUnboundedSender<T>, TracingUnboundedReceiver<T>) {
+		mpsc::unbounded()
+	}
+}
+
+
+#[cfg(feature = "metered")]
+mod inner {
+	//tracing implementation
+	use futures::channel::mpsc::{self,
+		UnboundedReceiver, UnboundedSender,
+		TryRecvError, TrySendError, SendError
+	};
+	use futures::{sink::Sink, task::{Poll, Context}, stream::{Stream, FusedStream}};
+	use std::pin::Pin;
+	use crate::metrics::UNBOUNDED_CHANNELS_COUNTER;
+
+	/// Wrapper Type around `UnboundedSender` that increases the global
+	/// measure when a message is added
+	#[derive(Debug)]
+	pub struct TracingUnboundedSender<T>(&'static str, UnboundedSender<T>);
+
+	// Strangely, deriving `Clone` requires that `T` is also `Clone`.
+	impl<T> Clone for TracingUnboundedSender<T> {
+		fn clone(&self) -> Self {
+			Self(self.0, self.1.clone())
+		}
+	}
+
+	/// Wrapper Type around `UnboundedReceiver` that decreases the global
+	/// measure when a message is polled
+	#[derive(Debug)]
+	pub struct TracingUnboundedReceiver<T>(&'static str, UnboundedReceiver<T>);
+
+	/// Wrapper around `mpsc::unbounded` that tracks the in- and outflow via
+	/// `UNBOUNDED_CHANNELS_COUNTER`
+	pub fn tracing_unbounded<T>(key: &'static str) ->(TracingUnboundedSender<T>, TracingUnboundedReceiver<T>) {
+		let (s, r) = mpsc::unbounded();
+		(TracingUnboundedSender(key.clone(), s), TracingUnboundedReceiver(key,r))
+	}
+
+	impl<T> TracingUnboundedSender<T> {
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn poll_ready(&self, ctx: &mut Context) -> Poll<Result<(), SendError>> {
+			self.1.poll_ready(ctx)
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn is_closed(&self) -> bool {
+			self.1.is_closed()
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn close_channel(&self) {
+			self.1.close_channel()
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn disconnect(&mut self) {
+			self.1.disconnect()
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
+			self.1.start_send(msg)
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn unbounded_send(&self, msg: T) -> Result<(), TrySendError<T>> {
+			self.1.unbounded_send(msg).map(|s|{
+				UNBOUNDED_CHANNELS_COUNTER.with_label_values(&[self.0, &"send"]).inc();
+				s
+			})
+		}
+
+		/// Proxy function to mpsc::UnboundedSender
+		pub fn same_receiver(&self, other: &UnboundedSender<T>) -> bool {
+			self.1.same_receiver(other)
+		}
+	}
+
+	impl<T> TracingUnboundedReceiver<T> {
+
+		fn consume(&mut self) {
+			// consume all items, make sure to reflect the updated count
+			let mut count = 0;
+			loop {
+				if self.1.is_terminated() {
+					break;
+				}
+
+				match self.try_next() {
+					Ok(Some(..)) => count += 1,
+					_ => break
+				}
+			}
+			// and discount the messages
+			if count > 0 {
+				UNBOUNDED_CHANNELS_COUNTER.with_label_values(&[self.0, &"dropped"]).inc_by(count);
+			}
+
+		}
+
+		/// Proxy function to mpsc::UnboundedReceiver
+		/// that consumes all messages first and updates the counter
+		pub fn close(&mut self) {
+			self.consume();
+			self.1.close()
+		}
+
+		/// Proxy function to mpsc::UnboundedReceiver
+		/// that discounts the messages taken out
+		pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
+			self.1.try_next().map(|s| {
+				if s.is_some() {
+					UNBOUNDED_CHANNELS_COUNTER.with_label_values(&[self.0, &"received"]).inc();
+				}
+				s
+			})
+		}
+	}
+
+	impl<T> Drop for TracingUnboundedReceiver<T> {
+		fn drop(&mut self) {
+			self.consume();
+		}
+	}
+
+	impl<T> Unpin for TracingUnboundedReceiver<T> {}
+
+	impl<T> Stream for TracingUnboundedReceiver<T> {
+		type Item = T;
+
+		fn poll_next(
+			self: Pin<&mut Self>,
+			cx: &mut Context<'_>,
+		) -> Poll<Option<T>> {
+			let s = self.get_mut();
+			match Pin::new(&mut s.1).poll_next(cx) {
+				Poll::Ready(msg) => {
+					if msg.is_some() {
+						UNBOUNDED_CHANNELS_COUNTER.with_label_values(&[s.0, "received"]).inc();
+				   	}
+					Poll::Ready(msg)
+				}
+				Poll::Pending => {
+					Poll::Pending
+				}
+			}
+		}
+	}
+
+	impl<T> FusedStream for TracingUnboundedReceiver<T> {
+		fn is_terminated(&self) -> bool {
+			self.1.is_terminated()
+		}
+	}
+
+	impl<T> Sink<T> for TracingUnboundedSender<T> {
+		type Error = SendError;
+
+		fn poll_ready(
+			self: Pin<&mut Self>,
+			cx: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			TracingUnboundedSender::poll_ready(&*self, cx)
+		}
+
+		fn start_send(
+			mut self: Pin<&mut Self>,
+			msg: T,
+		) -> Result<(), Self::Error> {
+			TracingUnboundedSender::start_send(&mut *self, msg)
+		}
+
+		fn poll_flush(
+			self: Pin<&mut Self>,
+			_: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
+		}
+
+		fn poll_close(
+			mut self: Pin<&mut Self>,
+			_: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			self.disconnect();
+			Poll::Ready(Ok(()))
+		}
+	}
+
+	impl<T> Sink<T> for &TracingUnboundedSender<T> {
+		type Error = SendError;
+
+		fn poll_ready(
+			self: Pin<&mut Self>,
+			cx: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			TracingUnboundedSender::poll_ready(*self, cx)
+		}
+
+		fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
+			self.unbounded_send(msg)
+				.map_err(TrySendError::into_send_error)
+		}
+
+		fn poll_flush(
+			self: Pin<&mut Self>,
+			_: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
+		}
+
+		fn poll_close(
+			self: Pin<&mut Self>,
+			_: &mut Context<'_>,
+		) -> Poll<Result<(), Self::Error>> {
+			self.close_channel();
+			Poll::Ready(Ok(()))
+		}
+	}
+}
+
+pub use inner::{tracing_unbounded, TracingUnboundedSender, TracingUnboundedReceiver};

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -196,6 +196,8 @@ pub type AccountSignature = sr25519::Signature;
 pub type AccountId = <AccountSignature as Verify>::Signer;
 /// A simple hash type for all our hashing.
 pub type Hash = H256;
+/// The hashing algorithm used.
+pub type Hashing = BlakeTwo256;
 /// The block number type used in this runtime.
 pub type BlockNumber = u64;
 /// Index of a transaction.

--- a/test-utils/runtime/transaction-pool/src/lib.rs
+++ b/test-utils/runtime/transaction-pool/src/lib.rs
@@ -1,18 +1,19 @@
-// Copyright 2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Test utils for the transaction pool together with the test runtime.
 //!
@@ -22,17 +23,18 @@ use codec::Encode;
 use parking_lot::RwLock;
 use sp_runtime::{
 	generic::{self, BlockId},
-	traits::{BlakeTwo256, Hash as HashT},
+	traits::{BlakeTwo256, Hash as HashT, Block as _, Header as _},
 	transaction_validity::{
 		TransactionValidity, ValidTransaction, TransactionValidityError, InvalidTransaction,
 		TransactionSource,
 	},
 };
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashSet, HashMap, BTreeMap};
 use substrate_test_runtime_client::{
 	runtime::{Index, AccountId, Block, BlockNumber, Extrinsic, Hash, Header, Transfer},
 	AccountKeyring::{self, *},
 };
+use sp_blockchain::CachedHeaderMetadata;
 
 /// Error type used by [`TestApi`].
 #[derive(Debug, derive_more::From, derive_more::Display)]
@@ -52,9 +54,8 @@ impl std::error::Error for Error {
 
 #[derive(Default)]
 pub struct ChainState {
-	pub block_by_number: HashMap<BlockNumber, Vec<Extrinsic>>,
-	pub block_by_hash: HashMap<Hash, Vec<Extrinsic>>,
-	pub header_by_number: HashMap<BlockNumber, Header>,
+	pub block_by_number: BTreeMap<BlockNumber, Vec<Block>>,
+	pub block_by_hash: HashMap<Hash, Block>,
 	pub nonces: HashMap<AccountId, u64>,
 	pub invalid_hashes: HashSet<Hash>,
 }
@@ -69,11 +70,7 @@ pub struct TestApi {
 impl TestApi {
 	/// Test Api with Alice nonce set initially.
 	pub fn with_alice_nonce(nonce: u64) -> Self {
-		let api = TestApi {
-			valid_modifier: RwLock::new(Box::new(|_| {})),
-			chain: Default::default(),
-			validation_requests: RwLock::new(Default::default()),
-		};
+		let api = Self::empty();
 
 		api.chain.write().nonces.insert(Alice.into(), nonce);
 
@@ -88,6 +85,9 @@ impl TestApi {
 			validation_requests: RwLock::new(Default::default()),
 		};
 
+		// Push genesis block
+		api.push_block(0, Vec::new());
+
 		api
 	}
 
@@ -96,46 +96,61 @@ impl TestApi {
 		*self.valid_modifier.write() = modifier;
 	}
 
-	/// Push block as a part of canonical chain under given number.
+	/// Push block under given number.
+	///
+	/// If multiple blocks exists with the same block number, the first inserted block will be
+	/// interpreted as part of the canonical chain.
 	pub fn push_block(&self, block_number: BlockNumber, xts: Vec<Extrinsic>) -> Header {
+		let parent_hash = {
+			let chain = self.chain.read();
+			block_number
+				.checked_sub(1)
+				.and_then(|num| {
+					chain.block_by_number
+						.get(&num)
+						.map(|blocks| {
+							blocks[0].header.hash()
+						})
+				}).unwrap_or_default()
+		};
+
+		self.push_block_with_parent(parent_hash, xts)
+	}
+
+	/// Push a block using the given `parent`.
+	///
+	/// Panics if `parent` does not exists.
+	pub fn push_block_with_parent(
+		&self,
+		parent: Hash,
+		xts: Vec<Extrinsic>,
+	) -> Header {
 		let mut chain = self.chain.write();
-		chain.block_by_number.insert(block_number, xts.clone());
+
+		// `Hash::default()` is the genesis parent hash
+		let block_number = if parent == Hash::default() {
+			0
+		} else {
+			*chain.block_by_hash
+				.get(&parent)
+				.expect("`parent` exists")
+				.header()
+				.number() + 1
+		};
+
 		let header = Header {
 			number: block_number,
 			digest: Default::default(),
-			extrinsics_root:  Default::default(),
-			parent_hash: block_number
-				.checked_sub(1)
-				.and_then(|num| {
-					chain.header_by_number.get(&num)
-						.cloned().map(|h| h.hash())
-				}).unwrap_or_default(),
-			state_root: Default::default(),
-		};
-		chain.block_by_hash.insert(header.hash(), xts);
-		chain.header_by_number.insert(block_number, header.clone());
-		header
-	}
-
-	/// Push a block without a number.
-	///
-	/// As a part of non-canonical chain.
-	pub fn push_fork_block(&self, block_hash: Hash, xts: Vec<Extrinsic>) {
-		let mut chain = self.chain.write();
-		chain.block_by_hash.insert(block_hash, xts);
-	}
-
-	pub fn push_fork_block_with_parent(&self, parent: Hash, xts: Vec<Extrinsic>) -> Header {
-		let mut chain = self.chain.write();
-		let blocknum = chain.block_by_number.keys().max().expect("block_by_number shouldn't be empty");
-		let header = Header {
-			number: *blocknum,
-			digest: Default::default(),
-			extrinsics_root:  Default::default(),
+			extrinsics_root: Hash::random(),
 			parent_hash: parent,
 			state_root: Default::default(),
 		};
-		chain.block_by_hash.insert(header.hash(), xts);
+
+		let hash = header.hash();
+		let block = Block::new(header.clone(), xts);
+		chain.block_by_hash.insert(hash, block.clone());
+		chain.block_by_number.entry(block_number).or_default().push(block);
+
 		header
 	}
 
@@ -169,11 +184,19 @@ impl TestApi {
 		let mut chain = self.chain.write();
 		chain.nonces.entry(account).and_modify(|n| *n += 1).or_insert(1);
 	}
+
+	/// Calculate a tree route between the two given blocks.
+	pub fn tree_route(
+		&self,
+		from: Hash,
+		to: Hash,
+	) -> Result<sp_blockchain::TreeRoute<Block>, Error> {
+		sp_blockchain::tree_route(self, from, to)
+	}
 }
 
 impl sc_transaction_graph::ChainApi for TestApi {
 	type Block = Block;
-	type Hash = Hash;
 	type Error = Error;
 	type ValidationFuture = futures::future::Ready<Result<TransactionValidity, Error>>;
 	type BodyFuture = futures::future::Ready<Result<Option<Vec<Extrinsic>>, Error>>;
@@ -217,7 +240,14 @@ impl sc_transaction_graph::ChainApi for TestApi {
 		&self,
 		at: &BlockId<Self::Block>,
 	) -> Result<Option<sc_transaction_graph::NumberFor<Self>>, Error> {
-		Ok(Some(number_of(at)))
+		Ok(match at {
+			generic::BlockId::Hash(x) => self.chain
+				.read()
+				.block_by_hash
+				.get(x)
+				.map(|b| *b.header.number()),
+			generic::BlockId::Number(num) => Some(*num),
+		})
 	}
 
 	fn block_id_to_hash(
@@ -226,34 +256,60 @@ impl sc_transaction_graph::ChainApi for TestApi {
 	) -> Result<Option<sc_transaction_graph::BlockHash<Self>>, Error> {
 		Ok(match at {
 			generic::BlockId::Hash(x) => Some(x.clone()),
-			generic::BlockId::Number(num) => {
-				self.chain.read()
-					.header_by_number.get(num)
-					.map(|h| h.hash())
-					.or_else(|| Some(Default::default()))
-			},
+			generic::BlockId::Number(num) => self.chain
+				.read()
+				.block_by_number
+				.get(num)
+				.map(|blocks| blocks[0].header().hash()),
 		})
 	}
 
 	fn hash_and_length(
 		&self,
 		ex: &sc_transaction_graph::ExtrinsicFor<Self>,
-	) -> (Self::Hash, usize) {
+	) -> (Hash, usize) {
 		Self::hash_and_length_inner(ex)
 	}
 
 	fn block_body(&self, id: &BlockId<Self::Block>) -> Self::BodyFuture {
 		futures::future::ready(Ok(match id {
-			BlockId::Number(num) => self.chain.read().block_by_number.get(num).cloned(),
-			BlockId::Hash(hash) => self.chain.read().block_by_hash.get(hash).cloned(),
+			BlockId::Number(num) => self.chain
+				.read()
+				.block_by_number
+				.get(num)
+				.map(|b| b[0].extrinsics().to_vec()),
+			BlockId::Hash(hash) => self.chain
+				.read()
+				.block_by_hash
+				.get(hash)
+				.map(|b| b.extrinsics().to_vec()),
 		}))
 	}
 }
 
-fn number_of(at: &BlockId<Block>) -> u64 {
-	match at {
-		generic::BlockId::Number(n) => *n as u64,
-		_ => 0,
+impl sp_blockchain::HeaderMetadata<Block> for TestApi {
+	type Error = Error;
+
+	fn header_metadata(
+		&self,
+		hash: Hash,
+	) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
+		let chain = self.chain.read();
+		let block = chain.block_by_hash.get(&hash).expect("Hash exists");
+
+		Ok(block.header().into())
+	}
+
+	fn insert_header_metadata(
+		&self,
+		_: Hash,
+		_: CachedHeaderMetadata<Block>,
+	) {
+		unimplemented!("Not implemented for tests")
+	}
+
+	fn remove_header_metadata(&self, _: Hash) {
+		unimplemented!("Not implemented for tests")
 	}
 }
 
@@ -270,4 +326,3 @@ pub fn uxt(who: AccountKeyring, nonce: Index) -> Extrinsic {
 	let signature = transfer.using_encoded(|e| who.sign(e)).into();
 	Extrinsic::Transfer { transfer, signature, exhaust_resources_when_not_first: false }
 }
-

--- a/utils/frame/rpc/system/src/lib.rs
+++ b/utils/frame/rpc/system/src/lib.rs
@@ -236,7 +236,11 @@ mod tests {
 		let _ = env_logger::try_init();
 		let client = Arc::new(substrate_test_runtime_client::new());
 		let pool = Arc::new(
-			BasicPool::new(Default::default(), Arc::new(FullChainApi::new(client.clone()))).0
+			BasicPool::new(
+				Default::default(),
+				Arc::new(FullChainApi::new(client.clone())),
+				None,
+			).0
 		);
 
 		let source = sp_runtime::transaction_validity::TransactionSource::External;


### PR DESCRIPTION
"Warp sync" (`git checkout`) the transaction pool client / primitives to upstream 2.0.0-rc3 version.

Other changes were incidental to make it integrate with our slightly older 2.0.0-alpha.5 client / primitives.

incidental changes:
- `futures::mpsc` uses are replaced by `sp_utils::mpsc`
- prometheus registry arg required to construct `BasicPool`

The included transaction pool upstream commit hashes are:
```
Fix transaction pool event sending
384be7e26e0e8222288bf3071ea523126bbba8de

Transaction pool added missed comment (small tidy up)
65fe00b7bd4d32398e3db7cbcdbbefedbac53df6

Revalidation tweak & logging for transaction pool
a8bf2601825ca7a5e2ce76f49b4117d930fc71fe

Fix transaction pool & network issues
85cd5569fd52b7de2c9628c470d947d60c843bc8

Fix transaction pruning in tx-pool
9fe0da54ff01747a84104562e61c7a2aab8da589

Tx Pool only prune txs from canonical blocks
Prevents some txs going missing by pruned out of non-canonical blocks.
9ce077465ac46a93ebaced4b47863952b3d63d33

Split tx pool and offchain notification handling
(improves performance underload, reducing timeouts)
b4b6ab998e0cc8ff65f8e84faa709d946f5d2060
```

---

For posterity, https://github.com/paritytech/substrate/commit/9ce077465ac46a93ebaced4b47863952b3d63d33 is the best upstream reference for the state of our client (~`rc3` but a few commits behind `master` at the time or writing)
