### PR TITLE
Merge reserved nodes feature to develop

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -678,7 +678,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		self.num_connected.load(Ordering::Relaxed)
 	}
 
-	pub fn set_reserved_nodes(&self, reserved_nodes:HashSet<PeerId> ) {
+	pub fn set_reserved_nodes(&self, reserved_nodes: HashSet<PeerId>) {
 		self.peerset.set_reserved_nodes(reserved_nodes);
 	}
 }

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -677,6 +677,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	pub fn num_connected(&self) -> usize {
 		self.num_connected.load(Ordering::Relaxed)
 	}
+
+	pub fn set_reserved_nodes(&self, reserved_nodes:HashSet<PeerId> ) {
+		self.peerset.set_reserved_nodes(reserved_nodes);
+	}
 }
 
 impl<B: BlockT + 'static, H: ExHashT> sp_consensus::SyncOracle

--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -121,8 +121,8 @@ impl PeersetHandle {
 		let _ = self.tx.unbounded_send(Action::RemoveFromPriorityGroup(group_id, peer_id));
 	}
 
-	/// Remove a peer from a priority group.
-	pub fn set_reserved_nodes(&self, reserved_nodes:HashSet<PeerId>) {
+	/// Sets the "reserved" priority group
+	pub fn set_reserved_nodes(&self, reserved_nodes: HashSet<PeerId>) {
 		let _ = self.tx.unbounded_send(Action::SetReservedNodes(reserved_nodes));
 	}
 
@@ -235,7 +235,7 @@ impl Peerset {
 		(peerset, handle)
 	}
 
-	pub fn set_reserved_nodes(&mut self, reserved_nodes : HashSet<PeerId>){
+	pub fn on_set_reserved_nodes(&mut self, reserved_nodes: HashSet<PeerId>){
 		self.data.set_priority_group(RESERVED_NODES, reserved_nodes);
 
 		// If network is private, kick un-wanted connection off the network
@@ -580,7 +580,7 @@ impl Stream for Peerset {
 				Action::RemoveFromPriorityGroup(group_id, peer_id) =>
 					self.on_remove_from_priority_group(&group_id, peer_id),
 				Action::SetReservedNodes(reserved_nodes) =>
-					self.set_reserved_nodes(reserved_nodes),
+					self.on_set_reserved_nodes(reserved_nodes),
 			}
 		}
 	}
@@ -591,9 +591,8 @@ mod tests {
 	use libp2p::PeerId;
 	use futures::prelude::*;
 	use super::{PeersetConfig, Peerset, Message, IncomingIndex, ReputationChange, BANNED_THRESHOLD};
-	use std::{pin::Pin, task::Poll, thread, time::Duration};
+	use std::{collections::HashSet, pin::Pin, task::Poll, thread, time::Duration};
 	use crate::RESERVED_NODES;
-	use std::collections::HashSet;
 
 	fn assert_messages(mut peerset: Peerset, messages: Vec<Message>) -> Peerset {
 		for expected_message in messages {

--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -636,12 +636,10 @@ mod tests {
 
 
 	#[test]
-	fn test_peerset_set_reserved_peer() {
+	fn test_set_reserved_peer_can_remove_reserved_nodes() {
 		let bootnode = PeerId::random();
 		let old_reserved_peer1 = PeerId::random();
 		let old_reserved_peer2 = PeerId::random();
-		let new_reserved_peer1 = PeerId::random();
-		let new_reserved_peer2 = PeerId::random();
 
 		let config = PeersetConfig {
 			in_peers: 5,
@@ -665,6 +663,36 @@ mod tests {
 		new_reserved.clear();
 		handle.set_reserved_nodes(new_reserved.clone());
 
+		assert_messages(peerset, vec![
+			Message::Connect(old_reserved_peer1.clone()),
+			Message::Connect(old_reserved_peer2.clone()),
+			Message::Drop(old_reserved_peer1),
+			Message::Drop(old_reserved_peer2),
+		]);
+	}
+
+
+	#[test]
+	fn test_set_reserved_peer_can_add_new_reserved_nodes() {
+		let bootnode = PeerId::random();
+		let new_reserved_peer1 = PeerId::random();
+		let new_reserved_peer2 = PeerId::random();
+
+		let config = PeersetConfig {
+			in_peers: 5,
+			out_peers: 5,
+			bootnodes: vec![bootnode.clone()],
+			reserved_only: true,
+			reserved_nodes: vec![],
+		};
+
+		let (peerset, handle) = Peerset::from_config(config);
+
+		// We add and replace reserved peers 1 at a time, so the events can happen in a
+		// deterministic and testable order
+
+		let mut new_reserved: HashSet<PeerId> = HashSet::new();
+
 		// Add new reserved nodes to be connected
 		new_reserved.insert(new_reserved_peer1.clone());
 		handle.set_reserved_nodes(new_reserved.clone());
@@ -672,10 +700,6 @@ mod tests {
 		handle.set_reserved_nodes(new_reserved);
 
 		assert_messages(peerset, vec![
-			Message::Connect(old_reserved_peer1.clone()),
-			Message::Connect(old_reserved_peer2.clone()),
-			Message::Drop(old_reserved_peer1),
-			Message::Drop(old_reserved_peer2),
 			Message::Connect(new_reserved_peer1),
 			Message::Connect(new_reserved_peer2),
 		]);


### PR DESCRIPTION
This feature branch adds the capability to set reserved nodes using onchain storage.

## Changes

* Reserved nodes can be set using the `set_reserved_nodes` call in `network/service`
* Tests added to peerset to ensure reserved nodes are updated correctly.

## Concerns

* None
