### PR TITLE
Add has_keys to session module

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -697,7 +697,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	pub fn has_keys(v: &T::ValidatorId) -> bool {
-		<NextKeys<T>>::get(v).is_some()
+		<NextKeys<T>>::contains_key(v)
 	}
 
 	fn put_keys(v: &T::ValidatorId, keys: &T::Keys) {

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -696,6 +696,10 @@ impl<T: Trait> Module<T> {
 		<NextKeys<T>>::take(v)
 	}
 
+	pub fn has_keys(v: &T::ValidatorId) -> bool {
+		<NextKeys<T>>::get(v).is_some()
+	}
+
 	fn put_keys(v: &T::ValidatorId, keys: &T::Keys) {
 		<NextKeys<T>>::insert(v, keys);
 	}

--- a/frame/session/src/tests.rs
+++ b/frame/session/src/tests.rs
@@ -315,3 +315,40 @@ fn return_true_if_more_than_third_is_disabled() {
 		assert_eq!(Session::disable_index(3), true);
 	});
 }
+
+#[test]
+fn session_has_keys() {
+	new_test_ext().execute_with(|| {
+		let new_keys = mock::MockSessionKeys::generate(None);
+		assert_ok!(
+			Session::set_keys(
+				Origin::signed(0),
+				<mock::Test as Trait>::Keys::decode(&mut &new_keys[..]).expect("Decode keys"),
+				vec![],
+			)
+		);
+		assert!(Session::has_keys(&0));
+	});
+}
+
+#[test]
+fn session_has_keys_is_false() {
+	new_test_ext().execute_with(|| {
+		assert!(Session::has_keys(&99) == false);
+	});
+}
+
+#[test]
+fn session_new_account_has_keys() {
+	new_test_ext().execute_with(|| {
+		let new_keys = mock::MockSessionKeys::generate(None);
+		assert_ok!(
+			Session::set_keys(
+				Origin::signed(99),
+				<mock::Test as Trait>::Keys::decode(&mut &new_keys[..]).expect("Decode keys"),
+				vec![],
+			)
+		);
+		assert!(Session::has_keys(&99));
+	});
+}


### PR DESCRIPTION
We want to be able to check with the session module whether a validator actually has its session keys configured before updating it with a new set of validators.

## Changes

* Add function `has_keys` to check if an account has associated keys added to the `session` module
* Some tests for `has_keys`

## Concerns

* None
