### PR TITLE
Upgrade pallet-aura to the latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc5"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pallet-aura"
-version = "2.0.0-alpha.5"
+version = "2.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
-license = "GPL-3.0"
+license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME AURA consensus pallet"
@@ -12,20 +12,20 @@ description = "FRAME AURA consensus pallet"
 sp-application-crypto = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/inherents" }
-sp-core = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
 pallet-session = { version = "2.0.0-alpha.5", default-features = false, path = "../session" }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/runtime" }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.5"}
 frame-support = { version = "2.0.0-alpha.5", default-features = false, path = "../support" }
-sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features = false, version = "0.8.0-alpha.5"}
+sp-consensus-aura = { version = "0.8.0-alpha.5", path = "../../primitives/consensus/aura", default-features = false }
 frame-system = { version = "2.0.0-alpha.5", default-features = false, path = "../system" }
 sp-timestamp = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/timestamp" }
 pallet-timestamp = { version = "2.0.0-alpha.5", default-features = false, path = "../timestamp" }
 
 
 [dev-dependencies]
+sp-core = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/core" }
+sp-io ={ version = "2.0.0-alpha.5", path = "../../primitives/io" }
 lazy_static = "1.4.0"
 parking_lot = "0.10.0"
 
@@ -35,8 +35,6 @@ std = [
 	"sp-application-crypto/std",
 	"codec/std",
 	"sp-inherents/std",
-	"sp-io/std",
-	"sp-core/std",
 	"sp-std/std",
 	"serde",
 	"sp-runtime/std",

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -1,18 +1,19 @@
-// Copyright 2017-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! # Aura Module
 //!
@@ -160,6 +161,27 @@ impl<T: Trait> FindAuthor<u32> for Module<T> {
 		None
 	}
 }
+
+/// We can not implement `FindAuthor` twice, because the compiler does not know if
+/// `u32 == T::AuthorityId` and thus, prevents us to implement the trait twice.
+#[doc(hidden)]
+pub struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
+
+impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>
+	for FindAccountFromAuthorIndex<T, Inner>
+{
+	fn find_author<'a, I>(digests: I) -> Option<T::AuthorityId>
+		where I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
+	{
+		let i = Inner::find_author(digests)?;
+
+		let validators = <Module<T>>::authorities();
+		validators.get(i as usize).map(|k| k.clone())
+	}
+}
+
+/// Find the authority ID of the Aura authority who authored the current block.
+pub type AuraAuthorId<T> = FindAccountFromAuthorIndex<T, Module<T>>;
 
 impl<T: Trait> IsMember<T::AuthorityId> for Module<T> {
 	fn is_member(authority_id: &T::AuthorityId) -> bool {

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -1,18 +1,19 @@
-// Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Test utilities
 
@@ -29,7 +30,7 @@ use sp_io;
 use sp_core::H256;
 
 impl_outer_origin!{
-	pub enum Origin for Test  where system = frame_system {}
+	pub enum Origin for Test where system = frame_system {}
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -1,18 +1,19 @@
-// Copyright 2017-2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Tests for the module.
 


### PR DESCRIPTION
Upgrade `pallet-aura` to the latest version: `2.0.0-alpha.5 -> 2.0.0-rc5`.

Notable commits:
- https://github.com/paritytech/substrate/commit/d9e989a4b2ac16f6484eb954ed893091c6ac5ae1 - starting commit of alpha.5 release
- https://github.com/paritytech/substrate/commit/dbf2163250833e6ac898e7f6c3c8f89f08a7c19d - licence update commit
- https://github.com/paritytech/substrate/commit/77819ad119f23a68b7478f3ac88e6c93a1677fc1 - wrapper implementation of `FindAuthor` trait

There aren't any business logic changes to cause side effects.