### PR TITLE
Improved the consortium permission module

### DIFF
--- a/prml/consortium-permission/src/lib.rs
+++ b/prml/consortium-permission/src/lib.rs
@@ -17,8 +17,11 @@
 //! # Consortium Permission module.
 //!
 //! This module is intended to store permissions that can be used in a Consortium Chain.
-//! Root can add and remove accounts as "issuers".
-//! "issuers" accounts can grant and revoke different permissions topics for other chain users.
+//! Root can manage the topics certain accounts (a.k.a "issuers") can make claims on.
+//!
+//! Once a topic is authorized for an "issuers", they can grant and revoke permissions for other
+//! chain users on this topic.
+//!
 //! Runtime modules can use this module to look up granted permissions when needed.
 //!
 //! ## Dispatchable methods
@@ -26,9 +29,10 @@
 //! There are a number of dispatchable methods. Some of which require Root privilege.
 //!
 //! ```ignore
-//! /// Manage issuers. Requires Root.
-//! pub fn add_issuer(origin, who: T::AccountId) { ... }
-//! pub fn remove_issuer(origin, who: T::AccountId) { ... }
+//! /// Manage issuers and their topics. Requires Root.
+//! pub fn add_issuer_with_topic(origin, who: T::AccountId, topic: Topic) { ... }
+//! pub fn remove_issuer_with_topic(origin, who: T::AccountId, topic: Topic) { ... }
+//! pub fn force_remove_issuer(origin, who: T::AccountId) { ... }
 //!
 //! /// Manage permission Topics. Requires Root.
 //! pub fn add_topic(origin, topic: Topic) { ... }
@@ -68,264 +72,283 @@ pub type Topic = Vec<u8>;
 /// Type used for values of corresponding topics.
 pub type Value = Vec<u8>;
 
-/// Allows runtime implmentation of issuer configuration.
-pub trait IssuerPermissions {
-	type AccountId;
-
-	/// Grants permissions for an account to be an issuer.
-	fn grant_issuer_permissions(issuer: &Self::AccountId);
-
-	/// Revokes permissions from an account to be a non-issuer.
-	fn revoke_issuer_permissions(issuer: &Self::AccountId);
-}
-
 /// The module's config trait.
 pub trait Trait: frame_system::Trait {
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-	/// The maximum number of bytes allowed for a topic name.
-	type MaximumTopicSize: Get<usize>;
-	/// The maximum number of bytes allowed for a value.
-	type MaximumValueSize: Get<usize>;
-	/// Provides an interface for setting issuer permissions
-	type IssuerPermissions: IssuerPermissions<AccountId = <Self as frame_system::Trait>::AccountId>;
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    /// The maximum number of bytes allowed for a topic name.
+    type MaximumTopicSize: Get<usize>;
+    /// The maximum number of bytes allowed for a value.
+    type MaximumValueSize: Get<usize>;
 }
 
 decl_storage! {
-	trait Store for Module<T: Trait> as ConsortiumPermission {
-		/// List of whitelisted accounts with permission to issue an attestation.
-		Issuers get(fn issuers): Vec<T::AccountId>;
-		/// List of all topics.
-		Topics get(fn topics): Vec<Topic>;
-		/// Map of topics to enabled / disabled status.
-		TopicEnabled get(fn topic_enabled): map hasher(twox_64_concat) Topic => bool;
-		/// Map of `holder, topic` to a `claim` containing `issuer, value`.
-		Claim get(fn claim): map hasher(twox_64_concat) (T::AccountId, Topic) => (T::AccountId, Value);
-		/// Map of issuer to all holder/topic pairs they have made claims on.
-		IssuerClaims get(fn issuer_claims): map hasher(twox_64_concat) T::AccountId => Vec<(T::AccountId, Topic)>;
-		/// Map of holder to all topics that have been claimed about them.
-		HolderClaims get(fn holder_claims): map hasher(twox_64_concat) T::AccountId => Vec<Topic>;
-	}
-	add_extra_genesis {
-		config(issuers): Vec<T::AccountId>;
-		config(topics): Vec<Vec<u8>>;
-		build(|config| {
-			Module::<T>::initialise_topics(&config.topics);
-			Module::<T>::initialise_issuers(&config.issuers);
-		})
-	}
+    trait Store for Module<T: Trait> as ConsortiumPermission {
+        /// List of whitelisted accounts with permission topics they are allowed to issue.
+        Issuers get(fn issuers): map hasher(twox_64_concat) T::AccountId => Vec<Topic>;
+        /// List of all topics.
+        Topics get(fn topics): Vec<Topic>;
+        /// Map of topics to enabled / disabled status.
+        TopicEnabled get(fn topic_enabled): map hasher(twox_64_concat) Topic => bool;
+        /// Map of `holder, topic` to a `claim` containing `issuer, value`.
+        Claim get(fn claim): map hasher(twox_64_concat) (T::AccountId, Topic) => (T::AccountId, Value);
+        /// Map of issuer to all holder/topic pairs they have made claims on.
+        IssuerClaims get(fn issuer_claims): map hasher(twox_64_concat) T::AccountId => Vec<(T::AccountId, Topic)>;
+        /// Map of holder to all topics that have been claimed about them.
+        HolderClaims get(fn holder_claims): map hasher(twox_64_concat) T::AccountId => Vec<Topic>;
+    }
+    add_extra_genesis {
+        config(issuers): Vec<(T::AccountId, Vec<Topic>)>;
+        config(topics): Vec<Vec<u8>>;
+        build(|config| {
+            Module::<T>::initialise_topics(&config.topics);
+            Module::<T>::initialise_issuers(&config.issuers);
+        })
+    }
 }
 
 decl_event! {
-	pub enum Event<T> where AccountId = <T as frame_system::Trait>::AccountId {
-		/// A new issuer is added.
-		IssuerAdded(AccountId),
-		/// An existing issuer is removed.
-		IssuerRemoved(AccountId),
-		/// A claim has been made.
-		ClaimMade(AccountId, AccountId, Topic, Value),
-		/// A claim has been revoked.
-		ClaimRevoked(AccountId, AccountId, Topic),
-		/// A claim has been revoked by sudo.
-		ClaimRevokedBySudo(AccountId, Topic),
-		/// A new topic is added.
-		TopicAdded(Topic),
-		/// An existing topic is enabled.
-		TopicEnabled(Topic),
-		/// An existing topic is disabled.
-		TopicDisabled(Topic),
-	}
+    pub enum Event<T> where AccountId = <T as frame_system::Trait>::AccountId {
+        /// Added a new topic to an issuer.
+        IssuerWithTopicAdded(AccountId, Topic),
+        /// Removed a topic from an issuer
+        IssuerWithTopicRemoved(AccountId, Topic),
+        /// An issuer is force-removed with all of its topics.
+        IssuerForceRemoved(AccountId),
+        /// A claim has been made.
+        ClaimMade(AccountId, AccountId, Topic, Value),
+        /// A claim has been revoked.
+        ClaimRevoked(AccountId, AccountId, Topic),
+        /// A claim has been revoked by sudo.
+        ClaimRevokedBySudo(AccountId, Topic),
+        /// A new topic is added.
+        TopicAdded(Topic),
+        /// An existing topic is enabled.
+        TopicEnabled(Topic),
+        /// An existing topic is disabled.
+        TopicDisabled(Topic),
+    }
 }
 
 decl_error! {
-	pub enum Error for Module<T: Trait> {
-		/// Must be an issuer to make a claim.
-		NotAnIssuer,
-		/// Issuer already exists in storage.
-		IssuerExists,
-		/// Topic does not exist.
-		InvalidTopic,
-		/// Topic is disabled.
-		DisabledTopic,
-		/// Topic already exists in storage.
-		TopicExists,
-		/// Topic name has too many bytes.
-		TopicExceedsAllowableSize,
-		/// Value has too many bytes.
-		ValueExceedsAllowableSize,
-		/// Attempt to remove claim that doesn't exist.
-		CannotRemoveNonExistentClaim,
-	}
+    pub enum Error for Module<T: Trait> {
+        /// The issuer is already authorized to make claim on this topic.
+        IssuerWithTopicAlreadyExists,
+        /// Issuer not authorized to make claim on this topic.
+        IssuerNotAuthorizedOnTopic,
+        /// Topic does not exist.
+        InvalidTopic,
+        /// Topic is disabled.
+        DisabledTopic,
+        /// Topic already exists in storage.
+        TopicExists,
+        /// Topic name has too many bytes.
+        TopicExceedsAllowableSize,
+        /// Value has too many bytes.
+        ValueExceedsAllowableSize,
+        /// Attempt to remove claim that doesn't exist.
+        CannotRemoveNonExistentClaim,
+    }
 }
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
-		// Initialises errors.
-		type Error = Error<T>;
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
+        // Initialises errors.
+        type Error = Error<T>;
 
-		// Initialises events.
-		fn deposit_event() = default;
+        // Initialises events.
+        fn deposit_event() = default;
 
-		/// Adds a new issuer as root.
-		pub fn add_issuer(origin, who: T::AccountId) {
-			ensure_root(origin)?;
-			let mut issuers = Self::issuers();
-			ensure!(!issuers.contains(&who), Error::<T>::IssuerExists);
-			issuers.push(who.clone());
-			Issuers::<T>::put(issuers);
+        /// Adds a new topic to the list of topics this issuer is allowed to make claims on.
+        /// Requires Root.
+        pub fn add_issuer_with_topic(origin, who: T::AccountId, topic: Topic) {
+            ensure_root(origin)?;
+            let mut current_topics = Self::issuers(&who);
+            ensure!(!current_topics.contains(&topic), Error::<T>::IssuerWithTopicAlreadyExists );
+            ensure!(Self::topics().contains(&topic), Error::<T>::InvalidTopic);
 
-			T::IssuerPermissions::grant_issuer_permissions(&who);
+            // Add to the topic from the list of topics "who" is authorized to make.
+            current_topics.push(topic.clone());
+            Issuers::<T>::insert(who.clone(), current_topics);
 
-			Self::deposit_event(RawEvent::IssuerAdded(who));
-		}
+            Self::deposit_event(RawEvent::IssuerWithTopicAdded(who, topic));
+        }
 
-		/// Removes an existing issuer as root.
-		pub fn remove_issuer(origin, who: T::AccountId) {
-			ensure_root(origin)?;
-			let mut issuers = Self::issuers();
-			ensure!(issuers.contains(&who), Error::<T>::NotAnIssuer);
-			issuers.retain(|x| *x != who);
-			Issuers::<T>::put(issuers);
+        /// Removes a topic this issuer is allowed to make claims on.
+        /// Requires Root.
+        pub fn remove_issuer_with_topic(origin, who: T::AccountId, topic: Topic) {
+            ensure_root(origin)?;
+            let mut current_topics = Self::issuers(&who);
+            ensure!(Self::topics().contains(&topic), Error::<T>::InvalidTopic);
+            ensure!(current_topics.contains(&topic), Error::<T>::IssuerNotAuthorizedOnTopic);
 
-			T::IssuerPermissions::revoke_issuer_permissions(&who);
+            // Remove the topic from "who" is authorized to make.
+            let index = current_topics.iter().position(|t| *t == topic).unwrap();
+            current_topics.remove(index);
 
-			Self::deposit_event(RawEvent::IssuerRemoved(who));
-		}
+            // If the list is now empty, remove from storage.
+            // Otherwise insert the new list of topics into storage.
+            if current_topics.is_empty(){
+                Issuers::<T>::remove(who.clone());
+            }
+            else {
+                Issuers::<T>::insert(who.clone(), current_topics);
+            }
 
-		/// Adds a new topic as root.
-		pub fn add_topic(origin, topic: Topic) {
-			ensure_root(origin)?;
-			Self::insert_topic(&topic)?;
-			Self::deposit_event(RawEvent::TopicAdded(topic));
-		}
+            Self::deposit_event(RawEvent::IssuerWithTopicRemoved(who, topic));
+        }
 
-		/// Enable an existing topic as root.
-		pub fn enable_topic(origin, topic: Topic) {
-			ensure_root(origin)?;
-			Self::update_topic(&topic, true)?;
-			Self::deposit_event(RawEvent::TopicEnabled(topic));
-		}
+        /// Removes this account from being a issuer. Also removes all topics it is allowed to
+        /// make claims on.
+        /// Requires Root.
+        pub fn force_remove_issuer(origin, who: T::AccountId) {
+            ensure_root(origin)?;
+            Issuers::<T>::remove(&who);
 
-		/// Disable an existing topic as root.
-		pub fn disable_topic(origin, topic: Topic) {
-			ensure_root(origin)?;
-			Self::update_topic(&topic, false)?;
-			Self::deposit_event(RawEvent::TopicDisabled(topic));
-		}
+            Self::deposit_event(RawEvent::IssuerForceRemoved(who));
+        }
 
-		/// Makes a claim on a topic about a holder.
-		pub fn make_claim(origin, holder: T::AccountId, topic: Topic, value: Value) {
-			let issuer = ensure_signed(origin)?;
-			ensure!(Self::issuers().contains(&issuer), Error::<T>::NotAnIssuer);
-			ensure!(Self::topics().contains(&topic), Error::<T>::InvalidTopic);
-			ensure!(Self::topic_enabled(&topic), Error::<T>::DisabledTopic);
-			ensure!(value.len() <= T::MaximumValueSize::get(), Error::<T>::ValueExceedsAllowableSize);
+        /// Adds a new topic as root.
+        pub fn add_topic(origin, topic: Topic) {
+            ensure_root(origin)?;
+            Self::insert_topic(&topic)?;
+            Self::deposit_event(RawEvent::TopicAdded(topic));
+        }
 
-			Self::do_make_claim(&issuer, &holder, &topic, &value);
+        /// Enable an existing topic as root.
+        pub fn enable_topic(origin, topic: Topic) {
+            ensure_root(origin)?;
+            Self::update_topic(&topic, true)?;
+            Self::deposit_event(RawEvent::TopicEnabled(topic));
+        }
 
-			Self::deposit_event(RawEvent::ClaimMade(issuer, holder, topic, value));
-		}
+        /// Disable an existing topic as root.
+        pub fn disable_topic(origin, topic: Topic) {
+            ensure_root(origin)?;
+            Self::update_topic(&topic, false)?;
+            Self::deposit_event(RawEvent::TopicDisabled(topic));
+        }
 
-		/// Revokes a preexisting claim about a holder.
-		pub fn revoke_claim(origin, holder: T::AccountId, topic: Topic) {
-			let issuer = ensure_signed(origin)?;
-			ensure!(Self::issuers().contains(&issuer), Error::<T>::NotAnIssuer);
-			ensure!(Self::holder_claims(&holder).contains(&topic), Error::<T>::CannotRemoveNonExistentClaim);
+        /// Makes a claim on a topic about a holder.
+        pub fn make_claim(origin, holder: T::AccountId, topic: Topic, value: Value) {
+            let issuer = ensure_signed(origin)?;
+            ensure!(Self::issuers(&issuer).contains(&topic), Error::<T>::IssuerNotAuthorizedOnTopic);
+            ensure!(Self::topics().contains(&topic), Error::<T>::InvalidTopic);
+            ensure!(Self::topic_enabled(&topic), Error::<T>::DisabledTopic);
+            ensure!(value.len() <= T::MaximumValueSize::get(), Error::<T>::ValueExceedsAllowableSize);
 
-			Self::do_revoke_claim(holder.clone(), topic.clone());
+            Self::do_make_claim(&issuer, &holder, &topic, &value);
 
-			Self::deposit_event(RawEvent::ClaimRevoked(issuer, holder, topic));
-		}
+            Self::deposit_event(RawEvent::ClaimMade(issuer, holder, topic, value));
+        }
 
-		/// Revokes a preexisting claim about a holder - root only.
-		pub fn sudo_revoke_claim(origin, holder: T::AccountId, topic: Topic) {
-			ensure_root(origin)?;
-			ensure!(Self::holder_claims(&holder).contains(&topic), Error::<T>::CannotRemoveNonExistentClaim);
+        /// Revokes a preexisting claim about a holder.
+        pub fn revoke_claim(origin, holder: T::AccountId, topic: Topic) {
+            let issuer = ensure_signed(origin)?;
+            ensure!(Self::issuers(&issuer).contains(&topic), Error::<T>::IssuerNotAuthorizedOnTopic);
+            ensure!(Self::holder_claims(&holder).contains(&topic), Error::<T>::CannotRemoveNonExistentClaim);
 
-			Self::do_revoke_claim(holder.clone(), topic.clone());
+            Self::do_revoke_claim(holder.clone(), topic.clone());
 
-			Self::deposit_event(RawEvent::ClaimRevokedBySudo(holder, topic));
-		}
-	}
+            Self::deposit_event(RawEvent::ClaimRevoked(issuer, holder, topic));
+        }
+
+        /// Revokes a preexisting claim about a holder - root only.
+        pub fn sudo_revoke_claim(origin, holder: T::AccountId, topic: Topic) {
+            ensure_root(origin)?;
+            ensure!(Self::holder_claims(&holder).contains(&topic), Error::<T>::CannotRemoveNonExistentClaim);
+
+            Self::do_revoke_claim(holder.clone(), topic.clone());
+
+            Self::deposit_event(RawEvent::ClaimRevokedBySudo(holder, topic));
+        }
+    }
 }
 
 impl<T: Trait> Module<T> {
-	/// Initialises whitelisted issuers configured in genesis.
-	fn initialise_issuers(issuers: &[T::AccountId]) {
-		Issuers::<T>::put(issuers.clone());
-		for issuer in issuers {
-			T::IssuerPermissions::grant_issuer_permissions(&issuer);
-		}
-	}
+    /// Initialises whitelisted issuers configured in genesis.
+    fn initialise_issuers(issuers: &Vec<(T::AccountId, Vec<Topic>)>) {
+        for (issuer, topics) in issuers {
+            Issuers::<T>::insert(issuer, topics);
+        }
+    }
 
-	/// Performs all storage changes to make a claim by an issuer on a topic about a holder.
-	pub fn do_make_claim(issuer: &T::AccountId, holder: &T::AccountId, topic: &Topic, value: &Value) {
-		let mut holder_claims = Self::holder_claims(&holder);
-		if !holder_claims.contains(&topic) {
-			holder_claims.push(topic.clone());
-			HolderClaims::<T>::insert(&holder, holder_claims);
-		} else {
-			// Remove from previous issuer's claim list
-			let (old_issuer, _) = Self::claim((&holder, &topic));
-			Self::remove_issuer_claim(old_issuer, holder.clone(), topic.clone());
-		}
+    /// Performs all storage changes to make a claim by an issuer on a topic about a holder.
+    pub fn do_make_claim(
+        issuer: &T::AccountId,
+        holder: &T::AccountId,
+        topic: &Topic,
+        value: &Value,
+    ) {
+        let mut holder_claims = Self::holder_claims(&holder);
+        if !holder_claims.contains(&topic) {
+            holder_claims.push(topic.clone());
+            HolderClaims::<T>::insert(&holder, holder_claims);
+        } else {
+            // Remove from previous issuer's claim list
+            let (old_issuer, _) = Self::claim((&holder, &topic));
+            Self::remove_issuer_with_topic_claim(old_issuer, holder.clone(), topic.clone());
+        }
 
-		let mut issuer_claims = Self::issuer_claims(&issuer);
-		if !issuer_claims.contains(&(holder.clone(), topic.clone())) {
-			issuer_claims.push((holder.clone(), topic.clone()));
-			IssuerClaims::<T>::insert(&issuer, issuer_claims);
-		}
+        let mut issuer_claims = Self::issuer_claims(&issuer);
+        if !issuer_claims.contains(&(holder.clone(), topic.clone())) {
+            issuer_claims.push((holder.clone(), topic.clone()));
+            IssuerClaims::<T>::insert(&issuer, issuer_claims);
+        }
 
-		Claim::<T>::insert((holder, topic), (issuer, value));
-	}
+        Claim::<T>::insert((holder, topic), (issuer, value));
+    }
 
-	/// Performs all storage changes to revoke a claim on a topic about a holder.
-	pub fn do_revoke_claim(holder: T::AccountId, topic: Topic) {
-		// Remove claim from issuer list
-		let (old_issuer, _) = Self::claim((&holder, &topic));
-		Self::remove_issuer_claim(old_issuer, holder.clone(), topic.clone());
+    /// Performs all storage changes to revoke a claim on a topic about a holder.
+    pub fn do_revoke_claim(holder: T::AccountId, topic: Topic) {
+        // Remove claim from issuer list
+        let (old_issuer, _) = Self::claim((&holder, &topic));
+        Self::remove_issuer_with_topic_claim(old_issuer, holder.clone(), topic.clone());
 
-		// Remove claim from holder list
-		let mut holder_claims = Self::holder_claims(&holder);
-		holder_claims.retain(|x| *x != topic.clone());
-		HolderClaims::<T>::insert(&holder, holder_claims);
+        // Remove claim from holder list
+        let mut holder_claims = Self::holder_claims(&holder);
+        holder_claims.retain(|x| *x != topic.clone());
+        HolderClaims::<T>::insert(&holder, holder_claims);
 
-		Claim::<T>::remove((holder, topic));
-	}
+        Claim::<T>::remove((holder, topic));
+    }
 
-	/// Removes a claim from a specific issuer's claim list.
-	fn remove_issuer_claim(issuer: T::AccountId, holder: T::AccountId, topic: Topic) {
-		let mut issuer_claims = Self::issuer_claims(&issuer);
-		issuer_claims.retain(|x| *x != (holder.clone(), topic.clone()));
-		IssuerClaims::<T>::insert(&issuer, issuer_claims);
-	}
+    /// Removes a claim from a specific issuer's claim list.
+    fn remove_issuer_with_topic_claim(issuer: T::AccountId, holder: T::AccountId, topic: Topic) {
+        let mut issuer_claims = Self::issuer_claims(&issuer);
+        issuer_claims.retain(|x| *x != (holder.clone(), topic.clone()));
+        IssuerClaims::<T>::insert(&issuer, issuer_claims);
+    }
 
-	/// Initialises reserved topics at genesis.
-	fn initialise_topics(topics: &Vec<Topic>) {
-		Topics::put(topics.clone());
-		for topic in topics {
-			TopicEnabled::insert(topic, true);
-		}
-	}
+    /// Initialises reserved topics at genesis.
+    fn initialise_topics(topics: &Vec<Topic>) {
+        Topics::put(topics.clone());
+        for topic in topics {
+            TopicEnabled::insert(topic, true);
+        }
+    }
 
-	/// Performs all storage changes to add a topic.
-	fn insert_topic(topic: &[u8]) -> DispatchResult {
-		ensure!(
-			topic.len() <= T::MaximumTopicSize::get(),
-			Error::<T>::TopicExceedsAllowableSize
-		);
-		let mut topics = Self::topics();
-		ensure!(!topics.contains(&topic.to_vec()), Error::<T>::TopicExists);
-		topics.push(topic.to_vec());
-		Topics::put(topics);
-		TopicEnabled::insert(topic, false);
-		Ok(())
-	}
+    /// Performs all storage changes to add a topic.
+    fn insert_topic(topic: &[u8]) -> DispatchResult {
+        ensure!(
+            topic.len() <= T::MaximumTopicSize::get(),
+            Error::<T>::TopicExceedsAllowableSize
+        );
+        let mut topics = Self::topics();
+        ensure!(!topics.contains(&topic.to_vec()), Error::<T>::TopicExists);
+        topics.push(topic.to_vec());
+        Topics::put(topics);
+        TopicEnabled::insert(topic, false);
+        Ok(())
+    }
 
-	/// Performs all storage changes to revoke a claim on a topic about a holder.
-	fn update_topic(topic: &Topic, enabled: bool) -> DispatchResult {
-		ensure!(TopicEnabled::contains_key(topic.clone()), Error::<T>::InvalidTopic);
-		TopicEnabled::mutate(topic, |status| *status = enabled);
-		Ok(())
-	}
+    /// Performs all storage changes to revoke a claim on a topic about a holder.
+    fn update_topic(topic: &Topic, enabled: bool) -> DispatchResult {
+        ensure!(
+            TopicEnabled::contains_key(topic.clone()),
+            Error::<T>::InvalidTopic
+        );
+        TopicEnabled::mutate(topic, |status| *status = enabled);
+        Ok(())
+    }
 }

--- a/prml/consortium-permission/src/mock.rs
+++ b/prml/consortium-permission/src/mock.rs
@@ -16,14 +16,15 @@
 
 use super::*;
 use frame_support::{
-	additional_traits::DummyDispatchVerifier, impl_outer_event, impl_outer_origin, parameter_types, weights::Weight,
+    additional_traits::DummyDispatchVerifier, impl_outer_event, impl_outer_origin, parameter_types,
+    weights::Weight,
 };
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-	Perbill,
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
 };
 
 pub type System = frame_system::Module<Test>;
@@ -36,134 +37,117 @@ pub const ACCESS_TOPIC: &[u8; 6] = b"access";
 pub const ACCESS_VALUE: u8 = 1;
 
 impl_outer_origin! {
-	pub enum Origin for Test  where system = frame_system {}
+    pub enum Origin for Test  where system = frame_system {}
 }
 
 mod consortium_permission {
-	pub use crate::Event;
+    pub use crate::Event;
 }
 
 impl_outer_event! {
-	pub enum TestEvent for Test {
-		frame_system,
-		consortium_permission<T>,
-	}
-}
-
-pub struct IssuerPermissionsMock;
-
-impl IssuerPermissions for IssuerPermissionsMock {
-	type AccountId = AccountId;
-	/// Give a new issuer access = true.
-	fn grant_issuer_permissions(issuer: &Self::AccountId) {
-		ConsortiumPermission::do_make_claim(
-			issuer,
-			issuer,
-			ACCESS_TOPIC.to_vec().as_ref(),
-			vec![ACCESS_VALUE].as_ref(),
-		);
-	}
-	/// Remove all self-claimed permissions from an issuer.
-	fn revoke_issuer_permissions(issuer: &Self::AccountId) {
-		let (claim_issuer, _) = ConsortiumPermission::claim((issuer, ACCESS_TOPIC.to_vec()));
-		if claim_issuer == *issuer {
-			ConsortiumPermission::do_revoke_claim(*issuer, ACCESS_TOPIC.to_vec());
-		}
-	}
+    pub enum TestEvent for Test {
+        frame_system,
+        consortium_permission<T>,
+    }
 }
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
-	pub const MaximumTopicSize: usize = 32;
-	pub const MaximumValueSize: usize = 32;
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+    pub const MaximumTopicSize: usize = 32;
+    pub const MaximumValueSize: usize = 32;
 }
 
 impl frame_system::Trait for Test {
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Call = ();
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = AccountId;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = TestEvent;
-	type BlockHashCount = BlockHashCount;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type MaximumBlockLength = MaximumBlockLength;
-	type Doughnut = ();
-	type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
-	type Version = ();
-	type ModuleToIndex = ();
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Call = ();
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type MaximumBlockLength = MaximumBlockLength;
+    type Doughnut = ();
+    type DelegatedDispatchVerifier = DummyDispatchVerifier<Self::Doughnut, Self::AccountId>;
+    type Version = ();
+    type ModuleToIndex = ();
 }
 
 impl Trait for Test {
-	type Event = TestEvent;
-	type MaximumTopicSize = MaximumTopicSize;
-	type MaximumValueSize = MaximumValueSize;
-	type IssuerPermissions = IssuerPermissionsMock;
+    type Event = TestEvent;
+    type MaximumTopicSize = MaximumTopicSize;
+    type MaximumValueSize = MaximumValueSize;
 }
 
 #[derive(Default)]
 pub struct ExtBuilder {
-	issuers: Vec<AccountId>,
-	topics: (Vec<Topic>, Vec<bool>),
-	genesis_issuers: Vec<AccountId>,
-	genesis_topics: Vec<Topic>,
+    issuers: Vec<(AccountId, Vec<Topic>)>,
+    topics: (Vec<Topic>, Vec<bool>),
+    genesis_issuers: Vec<(AccountId, Vec<Topic>)>,
+    genesis_topics: Vec<Topic>,
 }
 
 impl ExtBuilder {
-	pub fn issuer(mut self, issuer: AccountId) -> Self {
-		if !self.issuers.contains(&issuer) {
-			self.issuers.push(issuer);
-		}
-		self
-	}
+    pub fn issuer(mut self, issuer: Vec<(AccountId, Vec<Topic>)>) -> Self {
+        for i in issuer.into_iter() {
+            if !self.issuers.contains(&i) {
+                self.issuers.push(i);
+            }
+        }
+        self
+    }
 
-	pub fn topic(mut self, topic: &[u8], enabled: bool) -> Self {
-		if !self.topics.0.contains(&topic.to_owned()) {
-			self.topics.0.push(topic.to_owned());
-			self.topics.1.push(enabled);
-		}
-		self
-	}
+    pub fn topic(mut self, topic: &[u8], enabled: bool) -> Self {
+        if !self.topics.0.contains(&topic.to_owned()) {
+            self.topics.0.push(topic.to_owned());
+            self.topics.1.push(enabled);
+        }
+        self
+    }
 
-	pub fn genesis_issuer(mut self, issuer: AccountId) -> Self {
-		self.genesis_issuers.push(issuer);
-		self
-	}
+    pub fn genesis_issuer(mut self, issuer: Vec<(AccountId, Vec<Topic>)>) -> Self {
+        for i in issuer.into_iter() {
+            self.genesis_issuers.push(i);
+        }
+        self
+    }
 
-	pub fn genesis_topic(mut self, topic: &[u8]) -> Self {
-		self.genesis_topics.push(topic.to_owned());
-		self
-	}
+    pub fn genesis_topic(mut self, topic: &[u8]) -> Self {
+        self.genesis_topics.push(topic.to_owned());
+        self
+    }
 
-	pub fn build(self) -> TestExternalities {
-		let mut t: TestExternalities = frame_system::GenesisConfig::default()
-			.build_storage::<Test>()
-			.unwrap()
-			.into();
-		t.execute_with(|| {
-			<crate::Issuers<Test>>::put(self.issuers);
-			<crate::Topics>::put(&self.topics.0);
-			for i in 0..self.topics.0.len() {
-				<crate::TopicEnabled>::insert(&self.topics.0[i], self.topics.1[i]);
-			}
-			if !self.genesis_issuers.is_empty() {
-				ConsortiumPermission::initialise_issuers(&self.genesis_issuers)
-			}
-			if !self.genesis_topics.is_empty() {
-				ConsortiumPermission::initialise_topics(&self.genesis_topics)
-			}
-		});
-		t
-	}
+    pub fn build(self) -> TestExternalities {
+        let mut t: TestExternalities = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap()
+            .into();
+        t.execute_with(|| {
+            for i in self.issuers.into_iter() {
+                <crate::Issuers<Test>>::insert(i.0, i.1);
+            }
+            <crate::Topics>::put(&self.topics.0);
+            for i in 0..self.topics.0.len() {
+                <crate::TopicEnabled>::insert(&self.topics.0[i], self.topics.1[i]);
+            }
+            if !self.genesis_issuers.is_empty() {
+                ConsortiumPermission::initialise_issuers(&self.genesis_issuers)
+            }
+            if !self.genesis_topics.is_empty() {
+                ConsortiumPermission::initialise_topics(&self.genesis_topics)
+            }
+        });
+        t
+    }
 }

--- a/prml/consortium-permission/src/tests.rs
+++ b/prml/consortium-permission/src/tests.rs
@@ -27,613 +27,918 @@ const CHARLIE: AccountId = 2;
 
 #[test]
 fn initialise_issuers_works() {
-	ExtBuilder::default()
-		.genesis_topic(ACCESS_TOPIC)
-		.genesis_issuer(ALICE)
-		.build()
-		.execute_with(|| {
-			assert_eq!(ConsortiumPermission::issuers().contains(&ALICE), true);
-			assert_eq!(
-				ConsortiumPermission::claim((ALICE, ACCESS_TOPIC.to_vec())),
-				(ALICE, vec![ACCESS_VALUE])
-			);
-		})
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .genesis_issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            assert_eq!(
+                ConsortiumPermission::issuers(&ALICE),
+                vec![ACCESS_TOPIC.to_vec()]
+            );
+        })
 }
 
 #[test]
-fn add_issuer_requires_root() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(ConsortiumPermission::add_issuer(Origin::signed(ALICE), BOB), BadOrigin);
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-	});
+fn add_issuer_with_topic_requires_root() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::add_issuer_with_topic(
+                    Origin::signed(ALICE),
+                    BOB,
+                    ACCESS_TOPIC.to_vec()
+                ),
+                BadOrigin
+            );
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+        });
 }
 
 #[test]
-fn add_issuer_rejects_adding_existing_account() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, ALICE));
-		assert_noop!(
-			ConsortiumPermission::add_issuer(Origin::ROOT, ALICE),
-			Error::<Test>::IssuerExists
-		);
-	});
+fn add_issuer_with_topic_rejects_invalid_topics() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_noop!(
+                ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, ALICE, vec![0, 1, 2]),
+                Error::<Test>::InvalidTopic
+            );
+        });
 }
 
 #[test]
-fn add_issuer_populates_storage() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, ALICE));
-		assert_eq!(ConsortiumPermission::issuers(), vec![ALICE]);
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-		assert_eq!(ConsortiumPermission::issuers(), vec![ALICE, BOB]);
-	});
+fn add_issuer_with_topic_rejects_adding_existing_account() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_noop!(
+                ConsortiumPermission::add_issuer_with_topic(
+                    Origin::ROOT,
+                    ALICE,
+                    ACCESS_TOPIC.to_vec()
+                ),
+                Error::<Test>::IssuerWithTopicAlreadyExists
+            );
+        });
 }
 
 #[test]
-fn add_issuer_emits_events() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, ALICE));
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-		let events = System::events();
-		assert_eq!(events[0].event, TestEvent::consortium_permission(RawEvent::IssuerAdded(ALICE)));
-		assert_eq!(events[1].event, TestEvent::consortium_permission(RawEvent::IssuerAdded(BOB)));
-	});
+fn add_issuer_with_topic_populates_storage() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_eq!(
+                ConsortiumPermission::issuers(ALICE),
+                vec![ACCESS_TOPIC.to_vec()]
+            );
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_eq!(
+                ConsortiumPermission::issuers(BOB),
+                vec![ACCESS_TOPIC.to_vec()]
+            );
+        });
 }
 
 #[test]
-fn added_issuer_has_access_true() {
-	ExtBuilder::default()
-		.topic(ACCESS_TOPIC, true)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-			assert_eq!(
-				ConsortiumPermission::claim((BOB, ACCESS_TOPIC.to_vec())),
-				(BOB, vec![ACCESS_VALUE])
-			);
-		});
+fn add_issuer_with_topic_emits_events() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::IssuerWithTopicAdded(
+                    ALICE,
+                    ACCESS_TOPIC.to_vec()
+                ))
+            );
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::IssuerWithTopicAdded(
+                    BOB,
+                    ACCESS_TOPIC.to_vec()
+                ))
+            );
+        });
 }
 
 #[test]
-fn remove_issuer_requires_root() {
-	ExtBuilder::default().issuer(BOB).build().execute_with(|| {
-		assert_noop!(ConsortiumPermission::remove_issuer(Origin::signed(ALICE), BOB), BadOrigin);
-		assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-	});
+fn remove_issuer_with_topic_requires_root() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .issuer(vec![(BOB, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::remove_issuer_with_topic(
+                    Origin::signed(ALICE),
+                    BOB,
+                    ACCESS_TOPIC.to_vec()
+                ),
+                BadOrigin
+            );
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+        });
 }
 
 #[test]
-fn remove_issuer_rejects_removing_unknown_account() {
-	ExtBuilder::default().issuer(BOB).build().execute_with(|| {
-		assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-		assert_noop!(
-			ConsortiumPermission::remove_issuer(Origin::ROOT, ALICE),
-			Error::<Test>::NotAnIssuer
-		);
-	});
+fn remove_issuer_with_topic_rejects_removing_unknown_account() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .issuer(vec![(BOB, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_noop!(
+                ConsortiumPermission::remove_issuer_with_topic(
+                    Origin::ROOT,
+                    ALICE,
+                    ACCESS_TOPIC.to_vec()
+                ),
+                Error::<Test>::IssuerNotAuthorizedOnTopic
+            );
+        });
 }
 
 #[test]
-fn remove_issuer_populates_storage() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.issuer(BOB)
-		.build()
-		.execute_with(|| {
-			assert_eq!(ConsortiumPermission::issuers(), vec![ALICE, BOB]);
-			assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, ALICE));
-			assert_eq!(ConsortiumPermission::issuers(), vec![BOB]);
-			assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-			assert_eq!(ConsortiumPermission::issuers(), vec![]);
-		});
+fn remove_issuer_with_topic_rejects_invalid_topics() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .issuer(vec![(BOB, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_noop!(
+                ConsortiumPermission::remove_issuer_with_topic(Origin::ROOT, ALICE, vec![1, 2, 3]),
+                Error::<Test>::InvalidTopic
+            );
+        });
 }
 
 #[test]
-fn remove_issuer_emits_events() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.issuer(BOB)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, ALICE));
-			assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-			let events = System::events();
-			assert_eq!(
-				events[0].event,
-				TestEvent::consortium_permission(RawEvent::IssuerRemoved(ALICE))
-			);
-			assert_eq!(events[1].event, TestEvent::consortium_permission(RawEvent::IssuerRemoved(BOB)));
-		});
+fn remove_issuer_with_topic_updates_storage() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .genesis_topic(&[1, 2, 3, 4, 5])
+        .issuer(vec![
+            (ALICE, vec![ACCESS_TOPIC.to_vec(), vec![1, 2, 3, 4, 5]]),
+            (BOB, vec![ACCESS_TOPIC.to_vec()]),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_eq!(
+                ConsortiumPermission::issuers(ALICE),
+                vec![ACCESS_TOPIC.to_vec(), vec![1, 2, 3, 4, 5]]
+            );
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                ACCESS_TOPIC.to_vec()
+            ));
+            assert_eq!(
+                ConsortiumPermission::issuers(ALICE),
+                vec![vec![1, 2, 3, 4, 5]]
+            );
+
+            assert_eq!(
+                ConsortiumPermission::issuers(BOB),
+                vec![ACCESS_TOPIC.to_vec()]
+            );
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            // Bob now has no topics left. He should be removed from the "issuer" storage.
+            assert_eq!(<Issuers<Test>>::contains_key(BOB), false);
+        });
 }
 
 #[test]
-fn removed_issuer_loses_self_assigned_access() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-		assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-		assert_eq!(ConsortiumPermission::holder_claims(BOB), Vec::<Topic>::default());
-	});
+fn remove_issuer_with_topic_emits_events() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .genesis_topic(&[1, 2, 3, 4, 5])
+        .issuer(vec![
+            (ALICE, vec![ACCESS_TOPIC.to_vec(), vec![1, 2, 3, 4, 5]]),
+            (BOB, vec![ACCESS_TOPIC.to_vec()]),
+        ])
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                ALICE,
+                vec![1, 2, 3, 4, 5]
+            ));
+            assert_ok!(ConsortiumPermission::remove_issuer_with_topic(
+                Origin::ROOT,
+                BOB,
+                ACCESS_TOPIC.to_vec()
+            ));
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::IssuerWithTopicRemoved(
+                    ALICE,
+                    vec![1, 2, 3, 4, 5]
+                ))
+            );
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::IssuerWithTopicRemoved(
+                    BOB,
+                    ACCESS_TOPIC.to_vec()
+                ))
+            );
+        });
 }
 
 #[test]
-fn removed_issuer_does_not_lose_access_assigned_by_another_issuer() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::add_issuer(Origin::ROOT, BOB));
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				BOB,
-				b"access".to_vec(),
-				vec![0x1]
-			));
+fn force_remove_issuer_works() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .genesis_topic(&[1, 2, 3, 4, 5])
+        .issuer(vec![
+            (ALICE, vec![ACCESS_TOPIC.to_vec(), vec![1, 2, 3, 4, 5]]),
+            (BOB, vec![ACCESS_TOPIC.to_vec()]),
+        ])
+        .build()
+        .execute_with(|| {
+            // Force remove requires Root permission.
+            assert_ok!(ConsortiumPermission::force_remove_issuer(
+                Origin::ROOT,
+                ALICE
+            ));
+            assert_noop!(
+                ConsortiumPermission::force_remove_issuer(Origin::signed(ALICE), BOB),
+                BadOrigin
+            );
 
-			assert_ok!(ConsortiumPermission::remove_issuer(Origin::ROOT, BOB));
-			assert_eq!(ConsortiumPermission::holder_claims(BOB), [b"access".to_vec()]);
-		});
+            // Only ALICE is removed.
+            assert_eq!(<Issuers<Test>>::contains_key(ALICE), false);
+            assert_eq!(
+                ConsortiumPermission::issuers(BOB),
+                vec![ACCESS_TOPIC.to_vec()]
+            );
+
+            // The correct event should be deposited.
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::IssuerForceRemoved(ALICE))
+            );
+        });
 }
 
 // Claims
-
 #[test]
 fn claim_extrinsics_must_be_signed() {
-	ExtBuilder::default().issuer(ALICE).build().execute_with(|| {
-		let topic = String::from("access").into_bytes();
-		assert_noop!(
-			ConsortiumPermission::make_claim(Origin::NONE, CHARLIE, topic.clone(), vec![0x1]),
-			BadOrigin
-		);
-		assert_noop!(
-			ConsortiumPermission::revoke_claim(Origin::NONE, CHARLIE, topic.clone()),
-			BadOrigin
-		);
-	});
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_noop!(
+                ConsortiumPermission::make_claim(Origin::NONE, CHARLIE, topic.clone(), vec![0x1]),
+                BadOrigin
+            );
+            assert_noop!(
+                ConsortiumPermission::revoke_claim(Origin::NONE, CHARLIE, topic.clone()),
+                BadOrigin
+            );
+        });
 }
 
 #[test]
-fn claim_cannot_be_made_by_non_issuer() {
-	ExtBuilder::default().issuer(ALICE).build().execute_with(|| {
-		assert_noop!(
-			ConsortiumPermission::make_claim(
-				Origin::signed(BOB),
-				CHARLIE,
-				String::from("access").into_bytes(),
-				vec![0x1]
-			),
-			Error::<Test>::NotAnIssuer
-		);
-	});
+fn claim_cannot_be_made_by_unauthorized_issuer() {
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::make_claim(
+                    Origin::signed(BOB),
+                    CHARLIE,
+                    ACCESS_TOPIC.to_vec(),
+                    vec![0x1]
+                ),
+                Error::<Test>::IssuerNotAuthorizedOnTopic
+            );
+            assert_noop!(
+                ConsortiumPermission::make_claim(
+                    Origin::signed(ALICE),
+                    CHARLIE,
+                    vec![1, 2, 3, 4, 5],
+                    vec![0x1]
+                ),
+                Error::<Test>::IssuerNotAuthorizedOnTopic
+            );
+        });
 }
 
 #[test]
 fn claim_cannot_be_made_by_non_existent_topics() {
-	ExtBuilder::default().issuer(ALICE).build().execute_with(|| {
-		assert_noop!(
-			ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				String::from("fake-topic").into_bytes(),
-				vec![0x1]
-			),
-			Error::<Test>::InvalidTopic
-		);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                String::from("fake-topic").into_bytes(),
+                vec![0x1]
+            ),
+            Error::<Test>::IssuerNotAuthorizedOnTopic
+        );
+    });
 }
 
 #[test]
 fn claim_cannot_be_made_by_disabled_topics() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"disabled-topic", false)
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				ConsortiumPermission::make_claim(
-					Origin::signed(ALICE),
-					CHARLIE,
-					String::from("disabled-topic").into_bytes(),
-					vec![0x1]
-				),
-				Error::<Test>::DisabledTopic
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![b"disabled-topic".to_vec()])])
+        .topic(b"disabled-topic", false)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::make_claim(
+                    Origin::signed(ALICE),
+                    CHARLIE,
+                    String::from("disabled-topic").into_bytes(),
+                    vec![0x1]
+                ),
+                Error::<Test>::DisabledTopic
+            );
+        });
 }
 
 #[test]
 fn make_simple_claim() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			let topic = String::from("access").into_bytes();
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone(),
-				vec![0x1]
-			));
-			assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (ALICE, vec![0x1]));
-			assert_eq!(ConsortiumPermission::issuer_claims(ALICE), [(CHARLIE, topic.clone())]);
-			assert_eq!(ConsortiumPermission::holder_claims(CHARLIE), [topic.clone()]);
-			let events = System::events();
-			assert_eq!(
-				events[0].event,
-				TestEvent::consortium_permission(RawEvent::ClaimMade(ALICE, CHARLIE, topic, vec![0x1]))
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone(),
+                vec![0x1]
+            ));
+            assert_eq!(
+                ConsortiumPermission::claim((CHARLIE, &topic)),
+                (ALICE, vec![0x1])
+            );
+            assert_eq!(
+                ConsortiumPermission::issuer_claims(ALICE),
+                [(CHARLIE, topic.clone())]
+            );
+            assert_eq!(
+                ConsortiumPermission::holder_claims(CHARLIE),
+                [topic.clone()]
+            );
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::ClaimMade(
+                    ALICE,
+                    CHARLIE,
+                    topic,
+                    vec![0x1]
+                ))
+            );
+        });
 }
 
 #[test]
 fn reissue_simple_claim() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.issuer(BOB)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			let topic = String::from("access").into_bytes();
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone(),
-				vec![0x1]
-			));
-			// Reissue
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(BOB),
-				CHARLIE,
-				topic.clone(),
-				vec![0x0]
-			));
-			assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (BOB, vec![0x0]));
-			assert_eq!(ConsortiumPermission::issuer_claims(ALICE), []); // Claim moved off Alice
-			assert_eq!(ConsortiumPermission::issuer_claims(BOB), [(CHARLIE, topic.clone())]); // and onto Bob
-			assert_eq!(ConsortiumPermission::holder_claims(CHARLIE), [topic.clone()]);
-			let events = System::events();
-			assert_eq!(
-				events[1].event,
-				TestEvent::consortium_permission(RawEvent::ClaimMade(BOB, CHARLIE, topic.clone(), vec![0x0]))
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![
+            (ALICE, vec![ACCESS_TOPIC.to_vec()]),
+            (BOB, vec![ACCESS_TOPIC.to_vec()]),
+        ])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone(),
+                vec![0x1]
+            ));
+            // Reissue
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(BOB),
+                CHARLIE,
+                topic.clone(),
+                vec![0x0]
+            ));
+            assert_eq!(
+                ConsortiumPermission::claim((CHARLIE, &topic)),
+                (BOB, vec![0x0])
+            );
+            assert_eq!(ConsortiumPermission::issuer_claims(ALICE), []); // Claim moved off Alice
+            assert_eq!(
+                ConsortiumPermission::issuer_claims(BOB),
+                [(CHARLIE, topic.clone())]
+            ); // and onto Bob
+            assert_eq!(
+                ConsortiumPermission::holder_claims(CHARLIE),
+                [topic.clone()]
+            );
+            let events = System::events();
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::ClaimMade(
+                    BOB,
+                    CHARLIE,
+                    topic.clone(),
+                    vec![0x0]
+                ))
+            );
+        });
 }
 
 #[test]
 fn claim_value_is_too_damn_long() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				ConsortiumPermission::make_claim(
-					Origin::signed(ALICE),
-					CHARLIE,
-					String::from("access").into_bytes(),
-					vec![0x1; <mock::Test as Trait>::MaximumValueSize::get() + 1]
-				),
-				Error::<Test>::ValueExceedsAllowableSize
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::make_claim(
+                    Origin::signed(ALICE),
+                    CHARLIE,
+                    String::from("access").into_bytes(),
+                    vec![0x1; <mock::Test as Trait>::MaximumValueSize::get() + 1]
+                ),
+                Error::<Test>::ValueExceedsAllowableSize
+            );
+        });
 }
 
 #[test]
 fn claim_value_is_just_right() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				String::from("access").into_bytes(),
-				vec![0x1; <mock::Test as Trait>::MaximumValueSize::get()]
-			));
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                String::from("access").into_bytes(),
+                vec![0x1; <mock::Test as Trait>::MaximumValueSize::get()]
+            ));
+        });
 }
 
 #[test]
 fn claim_revocation_fails_if_it_doesnt_exist() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				ConsortiumPermission::revoke_claim(Origin::signed(ALICE), CHARLIE, String::from("access").into_bytes()),
-				Error::<Test>::CannotRemoveNonExistentClaim
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::revoke_claim(
+                    Origin::signed(ALICE),
+                    CHARLIE,
+                    String::from("access").into_bytes()
+                ),
+                Error::<Test>::CannotRemoveNonExistentClaim
+            );
+        });
 }
 
 #[test]
-fn claim_revocation_fails_with_non_issuer() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				String::from("access").into_bytes(),
-				vec![0x1]
-			));
-			assert_noop!(
-				ConsortiumPermission::revoke_claim(Origin::signed(BOB), CHARLIE, String::from("access").into_bytes()),
-				Error::<Test>::NotAnIssuer
-			);
-		});
+fn claim_revocation_fails_with_unauthorized_issuer() {
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                String::from("access").into_bytes(),
+                vec![0x1]
+            ));
+            assert_noop!(
+                ConsortiumPermission::revoke_claim(
+                    Origin::signed(BOB),
+                    CHARLIE,
+                    String::from("access").into_bytes()
+                ),
+                Error::<Test>::IssuerNotAuthorizedOnTopic
+            );
+        });
 }
 
 #[test]
 fn revoke_simple_claim() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			let topic = String::from("access").into_bytes();
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone(),
-				vec![0x1]
-			));
-			assert_ok!(ConsortiumPermission::revoke_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone()
-			));
-			assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
-			assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
-			assert_eq!(ConsortiumPermission::holder_claims(CHARLIE), Vec::<Topic>::default());
-			let events = System::events();
-			assert_eq!(
-				events[1].event,
-				TestEvent::consortium_permission(RawEvent::ClaimRevoked(ALICE, CHARLIE, topic.clone()))
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone(),
+                vec![0x1]
+            ));
+            assert_ok!(ConsortiumPermission::revoke_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone()
+            ));
+            assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
+            assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
+            assert_eq!(
+                ConsortiumPermission::holder_claims(CHARLIE),
+                Vec::<Topic>::default()
+            );
+            let events = System::events();
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::ClaimRevoked(
+                    ALICE,
+                    CHARLIE,
+                    topic.clone()
+                ))
+            );
+        });
 }
 
 #[test]
 fn revoke_someone_elses_claim() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.issuer(BOB)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			let topic = String::from("access").into_bytes();
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone(),
-				vec![0x1]
-			));
-			assert_ok!(ConsortiumPermission::revoke_claim(Origin::signed(BOB), CHARLIE, topic.clone()));
-			assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
-			assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
-			assert_eq!(ConsortiumPermission::issuer_claims(BOB), vec![]);
-			assert_eq!(ConsortiumPermission::holder_claims(CHARLIE), Vec::<Topic>::default());
-			let events = System::events();
-			assert_eq!(
-				events[1].event,
-				TestEvent::consortium_permission(RawEvent::ClaimRevoked(BOB, CHARLIE, topic.clone()))
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![
+            (ALICE, vec![ACCESS_TOPIC.to_vec()]),
+            (BOB, vec![ACCESS_TOPIC.to_vec()]),
+        ])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone(),
+                vec![0x1]
+            ));
+            assert_ok!(ConsortiumPermission::revoke_claim(
+                Origin::signed(BOB),
+                CHARLIE,
+                topic.clone()
+            ));
+            assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
+            assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
+            assert_eq!(ConsortiumPermission::issuer_claims(BOB), vec![]);
+            assert_eq!(
+                ConsortiumPermission::holder_claims(CHARLIE),
+                Vec::<Topic>::default()
+            );
+            let events = System::events();
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::ClaimRevoked(
+                    BOB,
+                    CHARLIE,
+                    topic.clone()
+                ))
+            );
+        });
 }
 
 #[test]
 fn sudo_claim_revocation_fails_without_sudo() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				String::from("access").into_bytes(),
-				vec![0x1]
-			));
-			assert_noop!(
-				ConsortiumPermission::sudo_revoke_claim(Origin::signed(ALICE), CHARLIE, String::from("access").into_bytes()),
-				BadOrigin
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                String::from("access").into_bytes(),
+                vec![0x1]
+            ));
+            assert_noop!(
+                ConsortiumPermission::sudo_revoke_claim(
+                    Origin::signed(ALICE),
+                    CHARLIE,
+                    String::from("access").into_bytes()
+                ),
+                BadOrigin
+            );
+        });
 }
 
 #[test]
 fn sudo_claim_revocation_fails_if_it_doesnt_exist() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				ConsortiumPermission::sudo_revoke_claim(Origin::ROOT, CHARLIE, String::from("access").into_bytes()),
-				Error::<Test>::CannotRemoveNonExistentClaim
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            assert_noop!(
+                ConsortiumPermission::sudo_revoke_claim(
+                    Origin::ROOT,
+                    CHARLIE,
+                    String::from("access").into_bytes()
+                ),
+                Error::<Test>::CannotRemoveNonExistentClaim
+            );
+        });
 }
 
 #[test]
 fn sudo_revoke_a_claim() {
-	ExtBuilder::default()
-		.issuer(ALICE)
-		.topic(b"access", true)
-		.build()
-		.execute_with(|| {
-			let topic = String::from("access").into_bytes();
-			assert_ok!(ConsortiumPermission::make_claim(
-				Origin::signed(ALICE),
-				CHARLIE,
-				topic.clone(),
-				vec![0x1]
-			));
-			assert_ok!(ConsortiumPermission::sudo_revoke_claim(Origin::ROOT, CHARLIE, topic.clone()));
-			assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
-			assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
-			assert_eq!(ConsortiumPermission::holder_claims(CHARLIE), Vec::<Topic>::default());
-			let events = System::events();
-			assert_eq!(
-				events[1].event,
-				TestEvent::consortium_permission(RawEvent::ClaimRevokedBySudo(CHARLIE, topic.clone()))
-			);
-		});
+    ExtBuilder::default()
+        .issuer(vec![(ALICE, vec![ACCESS_TOPIC.to_vec()])])
+        .topic(b"access", true)
+        .build()
+        .execute_with(|| {
+            let topic = String::from("access").into_bytes();
+            assert_ok!(ConsortiumPermission::make_claim(
+                Origin::signed(ALICE),
+                CHARLIE,
+                topic.clone(),
+                vec![0x1]
+            ));
+            assert_ok!(ConsortiumPermission::sudo_revoke_claim(
+                Origin::ROOT,
+                CHARLIE,
+                topic.clone()
+            ));
+            assert_eq!(ConsortiumPermission::claim((CHARLIE, &topic)), (0, vec![]));
+            assert_eq!(ConsortiumPermission::issuer_claims(ALICE), vec![]);
+            assert_eq!(
+                ConsortiumPermission::holder_claims(CHARLIE),
+                Vec::<Topic>::default()
+            );
+            let events = System::events();
+            assert_eq!(
+                events[1].event,
+                TestEvent::consortium_permission(RawEvent::ClaimRevokedBySudo(
+                    CHARLIE,
+                    topic.clone()
+                ))
+            );
+        });
 }
 
+// Topics
 #[test]
 fn initialise_topics_works() {
-	ExtBuilder::default()
-		.genesis_topic(ACCESS_TOPIC)
-		.build()
-		.execute_with(|| {
-			assert_eq!(Topics::get(), vec![ACCESS_TOPIC.to_vec()]);
-			assert_eq!(TopicEnabled::get(ACCESS_TOPIC.to_vec()), true);
-		})
+    ExtBuilder::default()
+        .genesis_topic(ACCESS_TOPIC)
+        .build()
+        .execute_with(|| {
+            assert_eq!(Topics::get(), vec![ACCESS_TOPIC.to_vec()]);
+            assert_eq!(TopicEnabled::get(ACCESS_TOPIC.to_vec()), true);
+        })
 }
 
 #[test]
 fn add_topic_requires_root() {
-	ExtBuilder::default().build().execute_with(|| {
-		let topic = b"test".to_vec();
-		assert_noop!(ConsortiumPermission::add_topic(Origin::signed(ALICE), topic.clone()), BadOrigin);
-		assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic));
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        let topic = b"test".to_vec();
+        assert_noop!(
+            ConsortiumPermission::add_topic(Origin::signed(ALICE), topic.clone()),
+            BadOrigin
+        );
+        assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic));
+    });
 }
 
 #[test]
 fn add_topic_rejects_adding_existing_topic() {
-	ExtBuilder::default().build().execute_with(|| {
-		let topic = b"test".to_vec();
-		assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic.clone()));
-		assert_noop!(ConsortiumPermission::add_topic(Origin::ROOT, topic), Error::<Test>::TopicExists);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        let topic = b"test".to_vec();
+        assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic.clone()));
+        assert_noop!(
+            ConsortiumPermission::add_topic(Origin::ROOT, topic),
+            Error::<Test>::TopicExists
+        );
+    });
 }
 
 #[test]
 fn add_topic_rejects_long_topic_name() {
-	ExtBuilder::default().build().execute_with(|| {
-		let topic = vec![0_u8; MaximumTopicSize::get() + 1];
-		assert_noop!(
-			ConsortiumPermission::add_topic(Origin::ROOT, topic),
-			Error::<Test>::TopicExceedsAllowableSize,
-		);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        let topic = vec![0_u8; MaximumTopicSize::get() + 1];
+        assert_noop!(
+            ConsortiumPermission::add_topic(Origin::ROOT, topic),
+            Error::<Test>::TopicExceedsAllowableSize,
+        );
+    });
 }
 
 #[test]
 fn add_topic_populates_storage() {
-	ExtBuilder::default().build().execute_with(|| {
-		let test_topic = b"test".to_vec();
-		assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, test_topic.clone()));
-		assert_eq!(ConsortiumPermission::topics(), vec![test_topic.clone()]);
-		assert_eq!(ConsortiumPermission::topic_enabled(test_topic), false);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        let test_topic = b"test".to_vec();
+        assert_ok!(ConsortiumPermission::add_topic(
+            Origin::ROOT,
+            test_topic.clone()
+        ));
+        assert_eq!(ConsortiumPermission::topics(), vec![test_topic.clone()]);
+        assert_eq!(ConsortiumPermission::topic_enabled(test_topic), false);
+    });
 }
 
 #[test]
 fn add_topic_emits_events() {
-	ExtBuilder::default().build().execute_with(|| {
-		let topic = b"test".to_vec();
-		assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic.clone()));
-		let events = System::events();
-		assert_eq!(events[0].event, TestEvent::consortium_permission(RawEvent::TopicAdded(topic)));
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        let topic = b"test".to_vec();
+        assert_ok!(ConsortiumPermission::add_topic(Origin::ROOT, topic.clone()));
+        let events = System::events();
+        assert_eq!(
+            events[0].event,
+            TestEvent::consortium_permission(RawEvent::TopicAdded(topic))
+        );
+    });
 }
 
 #[test]
 fn enable_topic_requires_root() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, false).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_noop!(
-			ConsortiumPermission::enable_topic(Origin::signed(ALICE), topic.clone()),
-			BadOrigin
-		);
-		assert_ok!(ConsortiumPermission::enable_topic(Origin::ROOT, topic));
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, false)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_noop!(
+                ConsortiumPermission::enable_topic(Origin::signed(ALICE), topic.clone()),
+                BadOrigin
+            );
+            assert_ok!(ConsortiumPermission::enable_topic(Origin::ROOT, topic));
+        });
 }
 
 #[test]
 fn enable_topic_rejects_unknown_topic() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			ConsortiumPermission::enable_topic(Origin::ROOT, b"test".to_vec()),
-			Error::<Test>::InvalidTopic
-		);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            ConsortiumPermission::enable_topic(Origin::ROOT, b"test".to_vec()),
+            Error::<Test>::InvalidTopic
+        );
+    });
 }
 
 #[test]
 fn enable_topic_updates_storage() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, false).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_ok!(ConsortiumPermission::enable_topic(Origin::ROOT, topic.clone()));
-		assert_eq!(ConsortiumPermission::topic_enabled(topic), true);
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, false)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_ok!(ConsortiumPermission::enable_topic(
+                Origin::ROOT,
+                topic.clone()
+            ));
+            assert_eq!(ConsortiumPermission::topic_enabled(topic), true);
+        });
 }
 
 #[test]
 fn enable_topic_emits_events() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, false).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_ok!(ConsortiumPermission::enable_topic(Origin::ROOT, topic.clone()));
-		let events = System::events();
-		assert_eq!(events[0].event, TestEvent::consortium_permission(RawEvent::TopicEnabled(topic)));
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, false)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_ok!(ConsortiumPermission::enable_topic(
+                Origin::ROOT,
+                topic.clone()
+            ));
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::TopicEnabled(topic))
+            );
+        });
 }
 
 #[test]
 fn disable_topic_requires_root() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, true).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_noop!(
-			ConsortiumPermission::disable_topic(Origin::signed(ALICE), topic.clone()),
-			BadOrigin
-		);
-		assert_ok!(ConsortiumPermission::disable_topic(Origin::ROOT, topic));
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, true)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_noop!(
+                ConsortiumPermission::disable_topic(Origin::signed(ALICE), topic.clone()),
+                BadOrigin
+            );
+            assert_ok!(ConsortiumPermission::disable_topic(Origin::ROOT, topic));
+        });
 }
 
 #[test]
 fn disable_topic_rejects_unknown_topic() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			ConsortiumPermission::disable_topic(Origin::ROOT, b"test".to_vec()),
-			Error::<Test>::InvalidTopic
-		);
-	});
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            ConsortiumPermission::disable_topic(Origin::ROOT, b"test".to_vec()),
+            Error::<Test>::InvalidTopic
+        );
+    });
 }
 
 #[test]
 fn disable_topic_updates_storage() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, true).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_ok!(ConsortiumPermission::disable_topic(Origin::ROOT, topic.clone()));
-		assert_eq!(ConsortiumPermission::topic_enabled(topic), false);
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, true)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_ok!(ConsortiumPermission::disable_topic(
+                Origin::ROOT,
+                topic.clone()
+            ));
+            assert_eq!(ConsortiumPermission::topic_enabled(topic), false);
+        });
 }
 
 #[test]
 fn disable_topic_emits_events() {
-	let topic = b"test";
-	ExtBuilder::default().topic(topic, true).build().execute_with(|| {
-		let topic = topic.to_vec();
-		assert_ok!(ConsortiumPermission::disable_topic(Origin::ROOT, topic.clone()));
-		let events = System::events();
-		assert_eq!(
-			events[0].event,
-			TestEvent::consortium_permission(RawEvent::TopicDisabled(topic))
-		);
-	});
+    let topic = b"test";
+    ExtBuilder::default()
+        .topic(topic, true)
+        .build()
+        .execute_with(|| {
+            let topic = topic.to_vec();
+            assert_ok!(ConsortiumPermission::disable_topic(
+                Origin::ROOT,
+                topic.clone()
+            ));
+            let events = System::events();
+            assert_eq!(
+                events[0].event,
+                TestEvent::consortium_permission(RawEvent::TopicDisabled(topic))
+            );
+        });
 }


### PR DESCRIPTION
* Consortium permission's issuer now also contains a list of authorized
topics associated with each issuer.
* These are managed by Root
* Updated mock and unit tests accordingly.
* Added a new unit test for force_remove_issuer