### PR TITLE
Tidy up docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             else
               DOCKER_TAG="${CIRCLE_TAG}"
             fi
-            docker build --pull -t plugnet/plugblockchain:$DOCKER_TAG -f ./.maintain/Dockerfile .
+            docker build --pull -t plugnet/plugblockchain:$DOCKER_TAG -f ./.plug/Dockerfile .
             docker push plugnet/plugblockchain:$DOCKER_TAG
           no_output_timeout: 60m
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,10 @@ jobs:
             else
               DOCKER_TAG="${CIRCLE_TAG}"
             fi
-            docker build --pull -t plugnet/plugblockchain:$DOCKER_TAG -f ./.plug/Dockerfile .
+            docker build --pull \
+              -t plugnet/plugblockchain:$DOCKER_TAG \
+              -t plugnet/plugblockchain:latest \
+              -f ./.plug/Dockerfile .
             docker push plugnet/plugblockchain:$DOCKER_TAG
           no_output_timeout: 60m
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ rls*.log
 .local
 **/hfuzz_target/
 **/hfuzz_workspace/
+.plug/data

--- a/.plug/Dockerfile
+++ b/.plug/Dockerfile
@@ -1,0 +1,62 @@
+# Note: We don't use Alpine and its packaged Rust/Cargo because they're too often out of date,
+# preventing them from being used to build Substrate/Polkadot/Plug.
+
+FROM phusion/baseimage:0.11 as builder
+LABEL description="Pl^g build image: The Pl^g binary is built here."
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG PROFILE=release
+WORKDIR /plug
+
+COPY . /plug
+
+RUN apt-get update && \
+	apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
+	apt-get install -y \
+	clang \
+	cmake \
+	git \
+	libssl-dev \
+	pkg-config
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+	export PATH="$PATH:$HOME/.cargo/bin" && \
+	rustup target add wasm32-unknown-unknown && \
+	rustup toolchain install nightly && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly && \
+	rustup default stable && \
+	cargo build "--$PROFILE"
+
+# ===== SECOND STAGE ======
+
+FROM phusion/baseimage:0.11
+LABEL description="Pl^g runner image: A minimal image for running Pl^g."
+ARG PROFILE=release
+
+RUN mv /usr/share/ca* /tmp && \
+	rm -rf /usr/share/*  && \
+	mv /tmp/ca-certificates /usr/share/ && \
+	useradd -m -u 1000 -U -s /bin/sh -d /plug plug && \
+	mkdir -p /plug/.local/share/plug && \
+	chown -R plug:plug /plug/.local && \
+	ln -s /plug/.local/share/plug /data
+
+COPY --from=builder /plug/target/$PROFILE/plug /usr/local/bin
+COPY --from=builder /plug/target/$PROFILE/subkey /usr/local/bin
+COPY --from=builder /plug/target/$PROFILE/node-rpc-client /usr/local/bin
+COPY --from=builder /plug/target/$PROFILE/chain-spec-builder /usr/local/bin
+
+# checks
+RUN ldd /usr/local/bin/plug && \
+	/usr/local/bin/plug --version
+
+# Shrinking
+RUN rm -rf /usr/lib/python* && \
+	rm -rf /usr/bin /usr/sbin /usr/share/man
+
+USER plug
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/data"]
+
+CMD ["/usr/local/bin/plug"]

--- a/.plug/Dockerfile
+++ b/.plug/Dockerfile
@@ -22,10 +22,7 @@ RUN apt-get update && \
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH="$PATH:$HOME/.cargo/bin" && \
-	rustup target add wasm32-unknown-unknown && \
-	rustup toolchain install nightly && \
-	rustup target add wasm32-unknown-unknown --toolchain nightly && \
-	rustup default stable && \
+	.plug/bootstrap && \
 	cargo build "--$PROFILE"
 
 # ===== SECOND STAGE ======

--- a/.plug/Dockerfile
+++ b/.plug/Dockerfile
@@ -59,4 +59,4 @@ USER plug
 EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
 
-CMD ["/usr/local/bin/plug"]
+ENTRYPOINT ["/usr/local/bin/plug"]

--- a/.plug/docker-compose.yml
+++ b/.plug/docker-compose.yml
@@ -8,16 +8,17 @@ services:
       - --alice
       - --base-path=/tmp/node
       - --chain=local
-      - --no-prometheus
       - --no-telemetry
       - --rpc-cors=all
       - --unsafe-rpc-external
       - --unsafe-ws-external
     ports:
-      - "9933:9933"    # rpc
-      - "9944:9944"    # ws
-      - "30333:30333"  # p2p
-    volumes: ["./data/alice:/tmp/node"]
+      - 9615:9615    # prometheus
+      - 9933:9933    # rpc
+      - 9944:9944    # ws
+      - 30333:30333  # p2p
+    volumes:
+      - ./data/alice:/tmp/node
 
   bob:
     image: plugnet/plugblockchain:latest
@@ -27,11 +28,11 @@ services:
       - --base-path=/tmp/node
       - --chain=local
       - --no-telemetry
-      - --no-prometheus
       - --rpc-cors=all
       - --unsafe-rpc-external
       - --unsafe-ws-external
-    volumes: ["./data/bob:/tmp/node"]
+    volumes:
+      - ./data/bob:/tmp/node
 
   charlie:
     image: plugnet/plugblockchain:latest
@@ -40,9 +41,33 @@ services:
       - --charlie
       - --base-path=/tmp/node
       - --chain=local
-      - --no-prometheus
       - --no-telemetry
       - --rpc-cors=all
       - --unsafe-rpc-external
       - --unsafe-ws-external
-    volumes: ["./data/charlie:/tmp/node"]
+    volumes:
+      - ./data/charlie:/tmp/node
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+    links:
+      - alice:alice
+      - bob:bob
+      - charlie:charlie
+    restart: always
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    volumes:
+      - ./grafana/provisioning/:/etc/grafana/provisioning
+    restart: always

--- a/.plug/docker-compose.yml
+++ b/.plug/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     depends_on:
       - prometheus
     ports:
-      - 3000:3000
+      - 3001:3000
     volumes:
       - ./grafana/provisioning/:/etc/grafana/provisioning
     restart: always

--- a/.plug/docker-compose.yml
+++ b/.plug/docker-compose.yml
@@ -1,8 +1,12 @@
 version: "3.7"
 
+x-default:
+  &plug-image
+  plugnet/plugblockchain:latest
+
 services:
   alice:
-    image: plugnet/plugblockchain:latest
+    image: *plug-image
     container_name: alice
     command:
       - --alice
@@ -21,7 +25,7 @@ services:
       - ./data/alice:/tmp/node
 
   bob:
-    image: plugnet/plugblockchain:latest
+    image: *plug-image
     container_name: bob
     command:
       - --bob
@@ -35,7 +39,7 @@ services:
       - ./data/bob:/tmp/node
 
   charlie:
-    image: plugnet/plugblockchain:latest
+    image: *plug-image
     container_name: charlie
     command:
       - --charlie

--- a/.plug/docker-compose.yml
+++ b/.plug/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.7"
+
+services:
+  alice:
+    image: plugnet/plugblockchain:latest
+    container_name: alice
+    command:
+      - --alice
+      - --base-path=/tmp/node
+      - --chain=local
+      - --no-prometheus
+      - --no-telemetry
+      - --rpc-cors=all
+      - --unsafe-rpc-external
+      - --unsafe-ws-external
+    ports:
+      - "9933:9933"    # rpc
+      - "9944:9944"    # ws
+      - "30333:30333"  # p2p
+    volumes: ["./data/alice:/tmp/node"]
+
+  bob:
+    image: plugnet/plugblockchain:latest
+    container_name: bob
+    command:
+      - --bob
+      - --base-path=/tmp/node
+      - --chain=local
+      - --no-telemetry
+      - --no-prometheus
+      - --rpc-cors=all
+      - --unsafe-rpc-external
+      - --unsafe-ws-external
+    volumes: ["./data/bob:/tmp/node"]
+
+  charlie:
+    image: plugnet/plugblockchain:latest
+    container_name: charlie
+    command:
+      - --charlie
+      - --base-path=/tmp/node
+      - --chain=local
+      - --no-prometheus
+      - --no-telemetry
+      - --rpc-cors=all
+      - --unsafe-rpc-external
+      - --unsafe-ws-external
+    volumes: ["./data/charlie:/tmp/node"]

--- a/.plug/grafana/provisioning/datasources/datasources.yml
+++ b/.plug/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090

--- a/.plug/logger.sh
+++ b/.plug/logger.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export TERM=xterm
+
 bold=$(tput bold)
 red=$(tput setaf 1)
 green=$(tput setaf 2)

--- a/.plug/logger.sh
+++ b/.plug/logger.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export TERM=xterm
+export TERM=${TERM:-xterm}
 
 bold=$(tput bold)
 red=$(tput setaf 1)

--- a/.plug/prometheus/prometheus.yml
+++ b/.plug/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: plug-nodes
+    static_configs:
+      - targets: ['alice:9615']
+        labels:
+          network: local
+      - targets: ['bob:9615']
+        labels:
+          network: local
+      - targets: ['charlie:9615']
+        labels:
+          network: local


### PR DESCRIPTION
Here are some tidy ups around docker to help streamline future testing.

Changes:
- Create and push with `latest` tag when `publish-docker` job is triggered
- Copy `.maintain/Dockerfile` into `.plug/Dockerfile` to maintain plug-specific Dockerfile
- Change `CMD` -> `ENTRYPOINT` in the Dockerfile so that parameters can be passed
- Export `TERM=xterm` for the case when `$TERM` isn't set (such as in docker)
- Add prometheus and grafana services (dashboards not yet created)