### PR TITLE
Added the IssuerPermissions back to solve an bug

### DIFF
--- a/prml/consortium-permission/src/lib.rs
+++ b/prml/consortium-permission/src/lib.rs
@@ -296,7 +296,9 @@ impl<T: Trait> Module<T> {
     fn initialise_issuers(issuers: &Vec<(T::AccountId, Vec<Topic>)>) {
         for (issuer, topics) in issuers {
             Issuers::<T>::insert(issuer, topics);
-            T::IssuerPermissions::grant_issuer_permissions(&issuer, &topic);
+            for topic in topics {
+                T::IssuerPermissions::grant_issuer_permissions(&issuer, &topic);
+            }
         }
     }
 

--- a/prml/consortium-permission/src/lib.rs
+++ b/prml/consortium-permission/src/lib.rs
@@ -296,6 +296,7 @@ impl<T: Trait> Module<T> {
     fn initialise_issuers(issuers: &Vec<(T::AccountId, Vec<Topic>)>) {
         for (issuer, topics) in issuers {
             Issuers::<T>::insert(issuer, topics);
+            T::IssuerPermissions::grant_issuer_permissions(&issuer, &topic);
         }
     }
 

--- a/prml/consortium-permission/src/mock.rs
+++ b/prml/consortium-permission/src/mock.rs
@@ -41,7 +41,7 @@ pub struct IssuerPermissionsMock;
 impl IssuerPermissions for IssuerPermissionsMock {
     type AccountId = AccountId;
     type Topic = Topic;
-    /// When an issuer is authorized to make claims on the "access" topic, also grant them the
+    /// When an issuer is authorized to make claims on the "access" topic, also grant themself the
     /// "access" permission.
     fn grant_issuer_permissions(issuer: &Self::AccountId, topic: &Topic) {
         if *topic == ACCESS_TOPIC {
@@ -53,7 +53,8 @@ impl IssuerPermissions for IssuerPermissionsMock {
             );
         }
     }
-    /// When an issuer's authority on the "access" topic is revoked, also revoke their "access" permission.
+    /// When an issuer's authority on the "access" topic is revoked, also revoke their self-claimed
+    /// "access" permission.
     fn revoke_issuer_permissions(issuer: &Self::AccountId, topic: &Topic) {
         if *topic == ACCESS_TOPIC {
             let (claim_issuer, _) = ConsortiumPermission::claim((issuer, ACCESS_TOPIC.to_vec()));

--- a/prml/consortium-permission/src/mock.rs
+++ b/prml/consortium-permission/src/mock.rs
@@ -41,7 +41,8 @@ pub struct IssuerPermissionsMock;
 impl IssuerPermissions for IssuerPermissionsMock {
     type AccountId = AccountId;
     type Topic = Topic;
-    /// Give a new issuer access = true.
+    /// When an issuer is authorized to make claims on the "access" topic, also grant them the
+    /// "access" permission.
     fn grant_issuer_permissions(issuer: &Self::AccountId, topic: &Topic) {
         if *topic == ACCESS_TOPIC {
             ConsortiumPermission::do_make_claim(
@@ -52,7 +53,7 @@ impl IssuerPermissions for IssuerPermissionsMock {
             );
         }
     }
-    /// Remove all self-claimed permissions from an issuer.
+    /// When an issuer's authority on the "access" topic is revoked, also revoke their "access" permission.
     fn revoke_issuer_permissions(issuer: &Self::AccountId, topic: &Topic) {
         if *topic == ACCESS_TOPIC {
             let (claim_issuer, _) = ConsortiumPermission::claim((issuer, ACCESS_TOPIC.to_vec()));

--- a/prml/consortium-permission/src/tests.rs
+++ b/prml/consortium-permission/src/tests.rs
@@ -320,13 +320,26 @@ fn remove_issuer_with_topic_emits_events() {
 }
 
 #[test]
-fn removed_issuer_loses_self_assigned_access() {
+fn removed_issuer_loses_only_self_assigned_access() {
     ExtBuilder::default().genesis_topic(ACCESS_TOPIC).build().execute_with(|| {
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, ALICE, ACCESS_TOPIC.to_vec()));
         assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+
+        // Revoking the "access" authority should also revoke the self-claimed "access" permission.
         assert_ok!(ConsortiumPermission::remove_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
         assert_eq!(ConsortiumPermission::holder_claims(BOB), Vec::<Topic>::default());
+
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+        assert_ok!(ConsortiumPermission::make_claim(Origin::signed(ALICE), BOB, ACCESS_TOPIC.to_vec(), vec![ACCESS_VALUE]));
+
+        // Since the "access" claim is now made by alice, BOB should keep the access permission even if its
+        // authority on the "access" topic has been revoked.
+        assert_ok!(ConsortiumPermission::remove_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+        assert_eq!(ConsortiumPermission::claim((BOB, ACCESS_TOPIC.to_vec())), (ALICE, vec![ACCESS_VALUE]) );
+
     });
 }
+
 
 #[test]
 fn force_remove_issuer_works() {
@@ -364,6 +377,28 @@ fn force_remove_issuer_works() {
             );
         });
 }
+
+#[test]
+fn force_remove_issuer_loses_only_self_assigned_access() {
+    ExtBuilder::default().genesis_topic(ACCESS_TOPIC).build().execute_with(|| {
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, ALICE, ACCESS_TOPIC.to_vec()));
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+
+        // Force-removing Bob should also revoke his self-claimed "access" permission.
+        assert_ok!(ConsortiumPermission::force_remove_issuer(Origin::ROOT, BOB));
+        assert_eq!(ConsortiumPermission::holder_claims(BOB), Vec::<Topic>::default());
+
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+        assert_ok!(ConsortiumPermission::make_claim(Origin::signed(ALICE), BOB, ACCESS_TOPIC.to_vec(), vec![ACCESS_VALUE]));
+
+        // Since the "access" claim is now made by alice, BOB should keep the access permission
+        // even if he is force_removed
+        assert_ok!(ConsortiumPermission::force_remove_issuer(Origin::ROOT, BOB));
+        assert_eq!(ConsortiumPermission::claim((BOB, ACCESS_TOPIC.to_vec())), (ALICE, vec![ACCESS_VALUE]) );
+
+    });
+}
+
 
 // Claims
 #[test]

--- a/prml/consortium-permission/src/tests.rs
+++ b/prml/consortium-permission/src/tests.rs
@@ -62,6 +62,20 @@ fn add_issuer_with_topic_requires_root() {
 }
 
 #[test]
+fn added_issuer_has_access_true() {
+    ExtBuilder::default()
+        .topic(ACCESS_TOPIC, true)
+        .build()
+        .execute_with(|| {
+            assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+            assert_eq!(
+                ConsortiumPermission::claim((BOB, ACCESS_TOPIC.to_vec())),
+                (BOB, vec![ACCESS_VALUE])
+            );
+        });
+}
+
+#[test]
 fn add_issuer_with_topic_rejects_invalid_topics() {
     ExtBuilder::default()
         .genesis_topic(ACCESS_TOPIC)
@@ -303,6 +317,15 @@ fn remove_issuer_with_topic_emits_events() {
                 ))
             );
         });
+}
+
+#[test]
+fn removed_issuer_loses_self_assigned_access() {
+    ExtBuilder::default().genesis_topic(ACCESS_TOPIC).build().execute_with(|| {
+        assert_ok!(ConsortiumPermission::add_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+        assert_ok!(ConsortiumPermission::remove_issuer_with_topic(Origin::ROOT, BOB, ACCESS_TOPIC.to_vec()));
+        assert_eq!(ConsortiumPermission::holder_claims(BOB), Vec::<Topic>::default());
+    });
 }
 
 #[test]


### PR DESCRIPTION
Resolves the problem where issuers don't have access to send extrinsics to give self the permission to send extrinsics.
Added some unit tests back
