### PR TITLE
Chore/benchmark ga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "prml-attestation",
+ "prml-generic-asset",
  "serde",
  "sp-api",
  "sp-authority-discovery",
@@ -5517,6 +5518,7 @@ dependencies = [
 name = "prml-generic-asset"
 version = "2.0.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",

--- a/bin/node/primitives/src/lib.rs
+++ b/bin/node/primitives/src/lib.rs
@@ -28,6 +28,9 @@ use sp_runtime::{
 /// An index to a block.
 pub type BlockNumber = u32;
 
+/// Asset ID for generic asset module.
+pub type AssetId = u32;
+
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
 

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -80,6 +80,7 @@ pallet-transaction-payment = { version = "2.0.0", default-features = false, path
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
 pallet-vesting = { version = "2.0.0", default-features = false, path = "../../../frame/vesting" }
 prml-attestation = { version = "2.0.0", default-features = false, path = "../../../prml/attestation" }
+prml-generic-asset = { version = "2.0.0", default-features = false, path = "../../../prml/generic-asset"}
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
@@ -146,6 +147,7 @@ std = [
 	"pallet-recovery/std",
 	"pallet-vesting/std",
 	"prml-attestation/std",
+	"prml-generic-asset/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -176,4 +178,5 @@ runtime-benchmarks = [
 	"frame-system-benchmarking",
 	"hex-literal",
 	"prml-attestation/runtime-benchmarks",
+	"prml-generic-asset/runtime-benchmarks",
 ]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -40,8 +40,9 @@ use sp_core::{
 	u32_trait::{_1, _2, _3, _4},
 	OpaqueMetadata,
 };
-pub use node_primitives::{AccountId, Signature};
+pub use node_primitives::{AccountId, AssetId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
+pub use prml_generic_asset::AssetInfo;
 use sp_api::impl_runtime_apis;
 use sp_runtime::{
 	Permill, Perbill, Perquintill, Percent, ApplyExtrinsicResult,
@@ -892,6 +893,13 @@ impl prml_attestation::Trait for Runtime {
 	type WeightInfo = weights::prml_attestation::WeightInfo;
 }
 
+impl prml_generic_asset::Trait for Runtime {
+	type AssetId = AssetId;
+	type Balance = Balance;
+	type Event = Event;
+	type WeightInfo = weights::prml_generic_asset::WeightInfo;
+}
+
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
@@ -931,6 +939,7 @@ construct_runtime!(
 		Proxy: pallet_proxy::{Module, Call, Storage, Event<T>},
 		Multisig: pallet_multisig::{Module, Call, Storage, Event<T>},
 		Attestation: prml_attestation::{Module, Call, Storage, Event<T>},
+		GenericAsset: prml_generic_asset::{Module, Call, Storage, Event<T>},
 	}
 );
 
@@ -1228,6 +1237,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_utility, Utility);
 			add_benchmark!(params, batches, pallet_vesting, Vesting);
 			add_benchmark!(params, batches, prml_attestation, Attestation);
+			add_benchmark!(params, batches, prml_generic_asset, GenericAsset);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/bin/node/runtime/src/weights/mod.rs
+++ b/bin/node/runtime/src/weights/mod.rs
@@ -33,3 +33,4 @@ pub mod pallet_utility;
 pub mod pallet_vesting;
 pub mod pallet_elections_phragmen;
 pub mod prml_attestation;
+pub mod prml_generic_asset;

--- a/bin/node/runtime/src/weights/prml_generic_asset.rs
+++ b/bin/node/runtime/src/weights/prml_generic_asset.rs
@@ -1,3 +1,19 @@
+// This file is part of Plug.
+
+// Copyright 2019-2020 Plug New Zealand Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
 
 #![allow(unused_parens)]

--- a/bin/node/runtime/src/weights/prml_generic_asset.rs
+++ b/bin/node/runtime/src/weights/prml_generic_asset.rs
@@ -1,0 +1,45 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl prml_generic_asset::WeightInfo for WeightInfo {
+    fn transfer() -> Weight {
+        (155_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn burn() -> Weight {
+        (92_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn create() -> Weight {
+        (77_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
+    fn mint() -> Weight {
+        (92_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_asset_info() -> Weight {
+        (70_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn update_permission() -> Weight {
+        (60_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn create_reserved() -> Weight {
+        (87_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+}

--- a/prml/generic-asset/Cargo.toml
+++ b/prml/generic-asset/Cargo.toml
@@ -14,6 +14,7 @@ sp-std = { path = "../../primitives/std", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }
 frame-support = { path = "../../frame/support", default-features = false }
 frame-system = { path = "../../frame/system", default-features = false }
+frame-benchmarking = { version = "2.0.0", default-features = false, path = "../../frame/benchmarking", optional = true }
 
 [dev-dependencies]
 sp-io ={ path = "../../primitives/io", default-features = false }
@@ -26,6 +27,8 @@ std =[
 	"serde/std",
 	"sp-std/std",
 	"sp-runtime/std",
+	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
 ]
+runtime-benchmarks = ["frame-benchmarking"]

--- a/prml/generic-asset/src/benchmarking.rs
+++ b/prml/generic-asset/src/benchmarking.rs
@@ -20,8 +20,6 @@ use super::*;
 
 use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller};
-// use sp_runtime::traits::Bounded;
-// use frame_support::traits::UnfilteredDispatchable;
 use crate::Module as GenericAsset;
 
 const SEED: u32 = 0;

--- a/prml/generic-asset/src/benchmarking.rs
+++ b/prml/generic-asset/src/benchmarking.rs
@@ -1,13 +1,10 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2020 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
+// Copyright 2019-2020 Plug New Zealand Limited
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/prml/generic-asset/src/benchmarking.rs
+++ b/prml/generic-asset/src/benchmarking.rs
@@ -1,0 +1,226 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic assets benchmarking.
+
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+
+use frame_system::RawOrigin;
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
+// use sp_runtime::traits::Bounded;
+// use frame_support::traits::UnfilteredDispatchable;
+use crate::Module as GenericAsset;
+
+const SEED: u32 = 0;
+
+benchmarks! {
+	_ { }
+
+	// Benchmark `transfer` extrinsic with the worst possible conditions:
+	// Transfer will kill the sender account.
+	// Transfer will create the recipient account.
+	transfer {
+		let caller: T::AccountId = whitelisted_caller();
+
+		// spending asset id
+		let asset_id = GenericAsset::<T>::spending_asset_id();
+		let initial_balance = T::Balance::from(5_000_000);
+		GenericAsset::<T>::set_free_balance(asset_id, &caller, initial_balance);
+
+		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let transfer_amount = T::Balance::from(5_000_000);
+	}: transfer(RawOrigin::Signed(caller.clone()), asset_id, recipient.clone(), transfer_amount)
+	verify {
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &caller), Zero::zero());
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &recipient), transfer_amount);
+	}
+
+	// Benchmark `burn`, GA's create comes from ROOT account. This always creates an asset.
+	// Mint some amount of new asset to an account and burn the asset from it.
+	burn {
+		let caller: T::AccountId = whitelisted_caller();
+		let initial_balance = T::Balance::from(5_000_000);
+		let asset_id = GenericAsset::<T>::next_asset_id();
+		let permissions = PermissionLatest::<T::AccountId>::new(caller.clone());
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+
+		let _ = GenericAsset::<T>::create(
+			RawOrigin::Root.into(),
+			caller.clone(),
+			asset_options,
+			AssetInfo::default()
+		);
+
+		let account: T::AccountId = account("bob", 0, SEED);
+
+		// Mint some asset to the account 'bob' so that 'bob' can burn those
+		let mint_amount = T::Balance::from(5_000_000);
+		let _ = GenericAsset::<T>::mint(RawOrigin::Signed(caller.clone()).into(), asset_id, account.clone(), mint_amount);
+
+		let burn_amount = T::Balance::from(5_000_000);
+	}: burn(RawOrigin::Signed(caller.clone()), asset_id, account.clone(), burn_amount)
+	verify {
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &account), Zero::zero());
+		assert_eq!(GenericAsset::<T>::total_issuance(asset_id), initial_balance);
+	}
+
+	// Benchmark `burn`, GA's create comes from ROOT account.
+	create {
+		let caller: T::AccountId = whitelisted_caller();
+		let initial_balance = T::Balance::from(5_000_000);
+		let permissions = PermissionLatest::<T::AccountId>::new(caller.clone());
+		let asset_id = GenericAsset::<T>::next_asset_id();
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+	}: create(RawOrigin::Root, caller.clone(), asset_options, AssetInfo::default())
+	verify {
+		assert_eq!(GenericAsset::<T>::total_issuance(&asset_id), initial_balance);
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &caller.clone()), initial_balance);
+	}
+
+	// Benchmark `mint`, create asset from ROOT account.
+	// Owner of the asset can then mint amount to 'recipient' account
+	mint {
+		let caller: T::AccountId = whitelisted_caller();
+		let mint_to: T::AccountId = account("recipient", 0, SEED);
+		let initial_balance = T::Balance::from(5_000_000);
+		let asset_id = GenericAsset::<T>::next_asset_id();
+		let permissions = PermissionLatest::<T::AccountId>::new(caller.clone());
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+		let _ = GenericAsset::<T>::create(
+			RawOrigin::Root.into(),
+			caller.clone(),
+			asset_options,
+			AssetInfo::default()
+		);
+
+		let mint_amount = T::Balance::from(1_000_000);
+	}: mint(RawOrigin::Signed(caller.clone()), asset_id, mint_to.clone(), mint_amount )
+	verify {
+		let total_issuance = T::Balance::from(6_000_000);
+		assert_eq!(GenericAsset::<T>::total_issuance(&asset_id), total_issuance);
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &mint_to.clone()), mint_amount);
+	}
+
+	// Benchmark `update_asset_info`, create asset from ROOT account.
+	// Update the asset info
+	update_asset_info {
+		let caller: T::AccountId = whitelisted_caller();
+		let web3_asset_info = AssetInfo::new(b"WEB3.0".to_vec(), 3);
+		let initial_balance = T::Balance::from(5_000_000);
+		let asset_id = GenericAsset::<T>::next_asset_id();
+		let permissions = PermissionLatest::<T::AccountId>::new(caller.clone());
+		let burn_amount = T::Balance::from(5_000);
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+		let _ = GenericAsset::<T>::create(
+			RawOrigin::Root.into(),
+			caller.clone(),
+			asset_options,
+			web3_asset_info.clone()
+		);
+
+		let web3_asset_info = AssetInfo::new(b"WEB3.1".to_vec(), 5);
+	}: update_asset_info(RawOrigin::Signed(caller.clone()), asset_id, web3_asset_info.clone())
+	verify {
+		assert_eq!(GenericAsset::<T>::asset_meta(asset_id), web3_asset_info);
+	}
+
+	// Benchmark `update_permission`, create asset from ROOT account with 'update' permission.
+	// Update permission to include update and mint
+	update_permission {
+		let caller: T::AccountId = whitelisted_caller();
+		let initial_balance = T::Balance::from(5_000_000);
+		let permissions = PermissionLatest {
+			update: Owner::Address(caller.clone()),
+			mint: Owner::None,
+			burn: Owner::None,
+		};
+
+		let new_permission = PermissionLatest {
+			update: Owner::Address(caller.clone()),
+			mint: Owner::Address(caller.clone()),
+			burn: Owner::None,
+		};
+		let asset_id = GenericAsset::<T>::next_asset_id();
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+		let _ = GenericAsset::<T>::create(
+			RawOrigin::Root.into(),
+			caller.clone(),
+			asset_options,
+			AssetInfo::default()
+		);
+	}: update_permission(RawOrigin::Signed(caller.clone()), asset_id, new_permission)
+	verify {
+		assert!(GenericAsset::<T>::check_permission(asset_id, &caller.clone(), &PermissionType::Mint));
+		assert!(!GenericAsset::<T>::check_permission(asset_id, &caller, &PermissionType::Burn));
+	}
+
+	// Benchmark `create_reserved`, create reserved asset from ROOT account.
+	create_reserved {
+		let caller: T::AccountId = whitelisted_caller();
+		let initial_balance = T::Balance::from(5_000_000);
+		let permissions = PermissionLatest::<T::AccountId>::new(caller.clone());
+		// create reserved asset with asset_id >= next_asset_id should fail so set the next asset id to some value
+		<NextAssetId<T>>::put(T::AssetId::from(10001));
+		let asset_id = T::AssetId::from(1000);
+		let asset_options :AssetOptions<T::Balance, T::AccountId> = AssetOptions {
+			initial_issuance: initial_balance,
+			permissions,
+		};
+	}: create_reserved(RawOrigin::Root, asset_id, asset_options, AssetInfo::default())
+	verify {
+		assert_eq!(GenericAsset::<T>::total_issuance(&asset_id), initial_balance);
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &T::AccountId::default()), initial_balance);
+		assert_eq!(asset_id,  T::AssetId::from(1000));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{ExtBuilder, Test};
+	use frame_support::assert_ok;
+
+	#[test]
+	fn generic_asset_benchmark_test() {
+		ExtBuilder::default().build().execute_with(|| {
+			assert_ok!(test_benchmark_transfer::<Test>());
+			assert_ok!(test_benchmark_burn::<Test>());
+			assert_ok!(test_benchmark_create::<Test>());
+			assert_ok!(test_benchmark_create_reserved::<Test>());
+			assert_ok!(test_benchmark_mint::<Test>());
+			assert_ok!(test_update_asset_info::<Test>());
+			assert_ok!(test_update_permission::<Test>());
+		});
+	}
+}

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -178,6 +178,7 @@ mod impls;
 mod mock;
 mod tests;
 mod types;
+mod benchmarking;
 
 // Export GA types/traits
 pub use self::imbalances::{CheckedImbalance, NegativeImbalance, OffsetResult, PositiveImbalance};


### PR DESCRIPTION
This PR is for adding benchmarking and generating weights for all the generic assets extrinsics..
cd bin/node/cli
cargo build --release --features runtime-benchmarks - compile benchmarking
Run benchmarking with
../../../target/release/substrate benchmark  --chain dev  --steps 50  --repeat 2  --pallet prml_generic_asset  --extrinsic "*" --raw --execution=wasm  --wasm-execution=compiled  --output

Have replaced the file bin/node/runtime/src/weights/prml_generic_asset.rs with the generated file..

Have covered all the path that would require more computation/resources.