### PR TITLE
Add default_weights impls for () in prml modules

### DIFF
--- a/prml/attestation/src/default_weight.rs
+++ b/prml/attestation/src/default_weight.rs
@@ -22,8 +22,7 @@
 
 use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
-pub struct WeightInfo;
-impl prml_attestation::WeightInfo for WeightInfo {
+impl crate::WeightInfo for () {
 	fn set_claim() -> Weight {
 		(89_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(2 as Weight))

--- a/prml/attestation/src/default_weight.rs
+++ b/prml/attestation/src/default_weight.rs
@@ -1,15 +1,37 @@
-use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+// This file is part of Plug.
 
-impl crate::WeightInfo for () {
+// Copyright (C) 2020 Parity Technologies (UK) Ltd. and Plug New Zealand.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl prml_attestation::WeightInfo for WeightInfo {
 	fn set_claim() -> Weight {
-		// taken from frame/balances
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+		(89_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn remove_claim() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+		(101_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 }

--- a/prml/generic-asset/src/default_weight.rs
+++ b/prml/generic-asset/src/default_weight.rs
@@ -1,40 +1,61 @@
-use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+// This file is part of Plug.
 
-impl crate::WeightInfo for () {
+// Copyright 2019-2020 Plug New Zealand Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+pub struct WeightInfo;
+impl prml_generic_asset::WeightInfo for WeightInfo {
 	fn transfer() -> Weight {
-		// taken from frame/balances
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
-	}
-	fn create() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
-	}
-	fn update_asset_info() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
-	}
-	fn mint() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+		(155_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn burn() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+		(92_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn create_reserved() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+	fn create() -> Weight {
+		(77_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
+	}
+	fn mint() -> Weight {
+		(92_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+	fn update_asset_info() -> Weight {
+		(70_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn update_permission() -> Weight {
-		(65_949_000 as Weight)
-			.saturating_mul(84)
-			.saturating_add(DbWeight::get().reads_writes(4, 2))
+		(60_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn create_reserved() -> Weight {
+		(87_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
 	}
 }

--- a/prml/generic-asset/src/default_weight.rs
+++ b/prml/generic-asset/src/default_weight.rs
@@ -21,8 +21,7 @@
 
 use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
-pub struct WeightInfo;
-impl prml_generic_asset::WeightInfo for WeightInfo {
+impl crate::WeightInfo for () {
 	fn transfer() -> Weight {
 		(155_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(4 as Weight))


### PR DESCRIPTION
These are useful so dependent runtimes can use `type WeightInfo = ()` correctly