### PR TITLE
RPC Restart Grandpa Voter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
+ "sp-utils",
  "structopt",
  "substrate-browser-utils",
  "substrate-build-script-utils",
@@ -3892,6 +3893,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-runtime",
  "sp-transaction-pool",
+ "sp-utils",
  "substrate-frame-rpc-system",
 ]
 
@@ -6976,6 +6978,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-keyring",
  "sp-runtime",
+ "sp-utils",
  "substrate-test-runtime-client",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6970,6 +6970,7 @@ dependencies = [
  "sc-finality-grandpa",
  "sc-network-test",
  "sc-rpc",
+ "sc-rpc-api",
  "serde",
  "serde_json",
  "sp-blockchain",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -57,6 +57,8 @@ sp-keyring = { version = "2.0.0", path = "../../../primitives/keyring" }
 sp-io = { version = "2.0.0", path = "../../../primitives/io" }
 sp-consensus = { version = "0.8.0", path = "../../../primitives/consensus/common" }
 sp-transaction-pool = { version = "2.0.0", path = "../../../primitives/transaction-pool" }
+sp-utils = { version = "2.0.0", path = "../../../primitives/utils" }
+
 
 # client dependencies
 sc-client-api = { version = "2.0.0", path = "../../../client/api" }

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -81,7 +81,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		client.clone(), &(client.clone() as Arc<_>), select_chain.clone(),
 	)?;
 	let justification_import = grandpa_block_import.clone();
-	let send_voter_commands = grandpa_block_import.clone().send_voter_commands;
+	let send_voter_commands = grandpa_block_import.send_voter_commands();
 
 	let (block_import, babe_link) = sc_consensus_babe::block_import(
 		sc_consensus_babe::Config::get_or_compute(&*client)?,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -81,6 +81,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		client.clone(), &(client.clone() as Arc<_>), select_chain.clone(),
 	)?;
 	let justification_import = grandpa_block_import.clone();
+	let send_voter_commands = grandpa_block_import.clone().send_voter_commands;
 
 	let (block_import, babe_link) = sc_consensus_babe::block_import(
 		sc_consensus_babe::Config::get_or_compute(&*client)?,
@@ -136,6 +137,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 					keystore: keystore.clone(),
 				},
 				grandpa: node_rpc::GrandpaDeps {
+					voter_worker_send_handle: send_voter_commands.clone(),
 					shared_voter_state: shared_voter_state.clone(),
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -31,5 +31,6 @@ sp-blockchain = { version = "2.0.0", path = "../../../primitives/blockchain" }
 sp-consensus = { version = "0.8.0", path = "../../../primitives/consensus/common" }
 sp-consensus-babe = { version = "0.8.0", path = "../../../primitives/consensus/babe" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
+sp-utils = { version = "2.0.0", path = "../../../primitives/utils" }
 sp-transaction-pool = { version = "2.0.0", path = "../../../primitives/transaction-pool" }
 substrate-frame-rpc-system = { version = "2.0.0", path = "../../../utils/frame/rpc/system" }

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -189,6 +189,7 @@ pub fn create_full<C, P, SC, B>(
 				justification_stream,
 				subscription_executor,
 				finality_provider,
+				deny_unsafe,
 			)
 		)
 	);

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -14,6 +14,7 @@ sc-rpc = { version = "2.0.0", path = "../../rpc" }
 sp-blockchain = { version = "2.0.0", path = "../../../primitives/blockchain" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
+sp-utils = { version = "2.0.0", path = "../../../primitives/utils" }
 finality-grandpa = { version = "0.12.3", features = ["derive-codec"] }
 jsonrpc-core = "15.0.0"
 jsonrpc-core-client = "15.0.0"

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4.8"
 derive_more = "0.99.2"
 parity-scale-codec = { version = "1.3.0", features = ["derive"] }
 sc-client-api = { version = "2.0.0", path = "../../api" }
+sc-rpc-api = { version = "0.8.0", path = "../../rpc-api" }
 
 [dev-dependencies]
 sc-block-builder = { version = "0.8.0", path = "../../block-builder" }

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -36,8 +36,9 @@ mod finality;
 mod notification;
 mod report;
 
-use sc_finality_grandpa::GrandpaJustificationStream;
-use sp_runtime::traits::Block as BlockT;
+use sc_finality_grandpa::{GrandpaJustificationStream, VoterCommand};
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_utils::mpsc::TracingUnboundedSender;
 
 use finality::{EncodedFinalityProofs, RpcFinalityProofProvider};
 use report::{ReportAuthoritySet, ReportVoterState, ReportedRoundStates};
@@ -56,6 +57,11 @@ pub trait GrandpaApi<Notification, Hash> {
 	/// ongoing background rounds.
 	#[rpc(name = "grandpa_roundState")]
 	fn round_state(&self) -> FutureResult<ReportedRoundStates>;
+
+	/// Returns the state of the current best round state as well as the
+	/// ongoing background rounds.
+	#[rpc(name = "grandpa_restartVoter")]
+	fn restart_voter(&self) -> FutureResult<ReportedRoundStates>;
 
 	/// Returns the block most recently finalized by Grandpa, alongside
 	/// side its justification.
@@ -95,6 +101,7 @@ pub trait GrandpaApi<Notification, Hash> {
 
 /// Implements the GrandpaApi RPC trait for interacting with GRANDPA.
 pub struct GrandpaRpcHandler<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
+ 	voter_worker_send_handle: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	authority_set: AuthoritySet,
 	voter_state: VoterState,
 	justification_stream: GrandpaJustificationStream<Block>,
@@ -108,6 +115,7 @@ impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 	/// Creates a new GrandpaRpcHandler instance.
 	pub fn new<E>(
 		authority_set: AuthoritySet,
+		voter_worker_send_handle: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 		voter_state: VoterState,
 		justification_stream: GrandpaJustificationStream<Block>,
 		executor: E,
@@ -119,6 +127,7 @@ impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 		let manager = SubscriptionManager::new(Arc::new(executor));
 		Self {
 			authority_set,
+ 			voter_worker_send_handle,
 			voter_state,
 			justification_stream,
 			manager,
@@ -136,6 +145,14 @@ where
 	ProofProvider: RpcFinalityProofProvider<Block> + Send + Sync + 'static,
 {
 	type Metadata = sc_rpc::Metadata;
+
+	fn restart_voter(&self) -> FutureResult<ReportedRoundStates> {
+		self.voter_worker_send_handle.unbounded_send(VoterCommand::Restart);
+		// return round state
+		let round_states = ReportedRoundStates::from(&self.authority_set, &self.voter_state);
+		let future = async move { round_states }.boxed();
+		Box::new(future.map_err(jsonrpc_core::Error::from).compat())
+	}
 
 	fn round_state(&self) -> FutureResult<ReportedRoundStates> {
 		let round_states = ReportedRoundStates::from(&self.authority_set, &self.voter_state);

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -59,8 +59,7 @@ pub trait GrandpaApi<Notification, Hash> {
 	#[rpc(name = "grandpa_roundState")]
 	fn round_state(&self) -> FutureResult<ReportedRoundStates>;
 
-	/// Returns the state of the current best round state as well as the
-	/// ongoing background rounds.
+	/// Restarts the grandpa voter future
 	#[rpc(name = "grandpa_restartVoter")]
 	fn restart_voter(&self) -> Result<(), jsonrpc_core::Error>;
 

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -726,6 +726,9 @@ where
 
 		let local_key = crate::is_voter(&self.voters, self.config.keystore.as_ref());
 
+		// TODO: debug here
+		debug!(target: "afg", "sc_finality_grandpa::environment::round_data:local key {:?}", local_key);
+
 		let has_voted = match self.voter_set_state.has_voted(round) {
 			HasVoted::Yes(id, vote) => {
 				if local_key.as_ref().map(|k| k == &id).unwrap_or(false) {

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -726,9 +726,6 @@ where
 
 		let local_key = crate::is_voter(&self.voters, self.config.keystore.as_ref());
 
-		// TODO: debug here
-		debug!(target: "afg", "sc_finality_grandpa::environment::round_data:local key {:?}", local_key);
-
 		let has_voted = match self.voter_set_state.has_voted(round) {
 			HasVoted::Yes(id, vote) => {
 				if local_key.as_ref().map(|k| k == &id).unwrap_or(false) {

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -60,11 +60,18 @@ pub struct GrandpaBlockImport<Backend, Block: BlockT, Client, SC> {
 	inner: Arc<Client>,
 	select_chain: SC,
 	authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
-	pub send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
+	send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
 	authority_set_hard_forks: HashMap<Block::Hash, PendingChange<Block::Hash, NumberFor<Block>>>,
 	justification_sender: GrandpaJustificationSender<Block>,
 	_phantom: PhantomData<Backend>,
+}
+
+impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Client, SC> {
+	/// Get the grandpa voter future command handle
+	pub fn send_voter_commands(&self) -> TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>> {
+		self.send_voter_commands.clone()
+	}
 }
 
 impl<Backend, Block: BlockT, Client, SC: Clone> Clone for

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -60,7 +60,7 @@ pub struct GrandpaBlockImport<Backend, Block: BlockT, Client, SC> {
 	inner: Arc<Client>,
 	select_chain: SC,
 	authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
-	send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
+	pub send_voter_commands: TracingUnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
 	authority_set_hard_forks: HashMap<Block::Hash, PendingChange<Block::Hash, NumberFor<Block>>>,
 	justification_sender: GrandpaJustificationSender<Block>,

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -626,6 +626,7 @@ fn global_communication<BE, Block: BlockT, C, N>(
 	NumberFor<Block>: BlockNumberOps,
 {
 	let is_voter = is_voter(voters, keystore).is_some();
+	debug!(target: "afg", "global communication: is_voter {:?}", is_voter);
 
 	// verification stream
 	let (global_in, global_out) = network.global_communication(
@@ -861,6 +862,7 @@ where
 		};
 
 		let voters = persistent_data.authority_set.current_authorities();
+		debug!(target: "afg", "VoterWork::new voters: {:?}", voters.clone());
 		let env = Arc::new(Environment {
 			client,
 			select_chain,
@@ -938,6 +940,8 @@ where
 
 				let last_completed_round = completed_rounds.last();
 
+				// TODO: Maybe this create is not aware of the new session key availability
+				// https://github.com/paritytech/finality-grandpa/blob/fab75b5f12235a8758dbb112e2fed3e7014b3e86/src/voter/voting_round.rs#L127
 				let voter = voter::Voter::new(
 					self.env.clone(),
 					(*self.env.voters).clone(),

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -389,7 +389,7 @@ pub enum VoterCommand<H, N> {
 	Pause(String),
 	/// New authorities.
 	ChangeAuthorities(NewAuthoritySet<H, N>),
-	/// Restart the local grandpa worker
+	/// Restart the local grandpa voter.
 	Restart,
 }
 
@@ -398,7 +398,7 @@ impl<H, N> fmt::Display for VoterCommand<H, N> {
 		match *self {
 			VoterCommand::Pause(ref reason) => write!(f, "Pausing voter: {}", reason),
 			VoterCommand::ChangeAuthorities(_) => write!(f, "Changing authorities"),
-			VoterCommand::Restart => write!(f, "Restart the local grandpa worker"),
+			VoterCommand::Restart => write!(f, "Restart the local grandpa voter"),
 		}
 	}
 }
@@ -629,7 +629,6 @@ fn global_communication<BE, Block: BlockT, C, N>(
 	NumberFor<Block>: BlockNumberOps,
 {
 	let is_voter = is_voter(voters, keystore).is_some();
-	debug!(target: "afg", "global communication: is_voter {:?}", is_voter);
 
 	// verification stream
 	let (global_in, global_out) = network.global_communication(
@@ -865,7 +864,6 @@ where
 		};
 
 		let voters = persistent_data.authority_set.current_authorities();
-		debug!(target: "afg", "VoterWork::new voters: {:?}", voters.clone());
 		let env = Arc::new(Environment {
 			client,
 			select_chain,
@@ -943,7 +941,6 @@ where
 
 				let last_completed_round = completed_rounds.last();
 
-				// TODO: Maybe this create is not aware of the new session key availability
 				let voter = voter::Voter::new(
 					self.env.clone(),
 					(*self.env.voters).clone(),
@@ -1041,7 +1038,7 @@ where
 				Ok(())
 			}
 			VoterCommand::Restart => {
-				// This should do
+				info!(target: "afg", "Restarting grandpa voter...");
 				self.rebuild_voter();
 				Ok(())
 			}

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -376,9 +376,13 @@ impl<Block, Network> BlockSyncRequester<Block> for NetworkBridge<Block, Network>
 /// A new authority set along with the canonical block it changed at.
 #[derive(Debug)]
 pub struct NewAuthoritySet<H, N> {
+	/// Canonical block number
 	pub canon_number: N,
+	/// Canonical block hash
 	pub canon_hash: H,
+	/// Authority set id
 	pub set_id: SetId,
+	/// The authority IDs
 	pub authorities: AuthorityList,
 }
 
@@ -1038,7 +1042,7 @@ where
 				Ok(())
 			}
 			VoterCommand::Restart => {
-				info!(target: "afg", "Restarting grandpa voter...");
+				info!(target: "afg", "👴 restarting grandpa voter...");
 				self.rebuild_voter();
 				Ok(())
 			}

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -334,16 +334,7 @@ where
 
 				set_state
 			},
-			VoterCommand::Restart => {
-				let prev = self.persistent_data.set_state.read();
-				let set_state = VoterSetState::Paused { 
-					completed_rounds: prev.completed_rounds(),
-				};
-
-				crate::aux_schema::write_voter_set_state(&*self.client, &set_state)?;
-
-				set_state
-			},
+			VoterCommand::Restart => return Ok(()),
 		}.into();
 
 		self.rebuild_observer();

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -334,6 +334,16 @@ where
 
 				set_state
 			},
+			VoterCommand::Restart => {
+				let prev = self.persistent_data.set_state.read();
+				let set_state = VoterSetState::Paused { 
+					completed_rounds: prev.completed_rounds(),
+				};
+
+				crate::aux_schema::write_voter_set_state(&*self.client, &set_state)?;
+
+				set_state
+			},
 		}.into();
 
 		self.rebuild_observer();


### PR DESCRIPTION
Adds an RPC to trigger a "restart" of the grandpa voter
This allows the node to use new grandpa session/authority keys without a full node restart or waiting for authority set change event.

Steps to reproduce:
1) Start a local node `--chain=dev --validator --rpc-method=Unsafe`
2) Insert session keys for babe and gran
3) trigger the worker restart: `curl -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "method":"grandpa_restartVoter", "params":[], "id": 1 }' http://localhost:9933`

<img width="896" alt="Screen Shot 2021-01-21 at 11 53 12" src="https://user-images.githubusercontent.com/5133901/105250920-709b6980-5bdf-11eb-94a4-885e62bef2f9.png">

cc: https://github.com/paritytech/substrate/issues/7268 