### PR TITLE
Use a StoredMap to indicate the existence of generic asset accounts 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,6 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "prml-attestation",
- "prml-generic-asset",
  "serde",
  "sp-api",
  "sp-authority-discovery",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -87,7 +87,6 @@ pallet-transaction-payment = { version = "3.0.0", default-features = false, path
 pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
 pallet-vesting = { version = "3.0.0", default-features = false, path = "../../../frame/vesting" }
 prml-attestation = { version = "3.0.0", default-features = false, path = "../../../prml/attestation" }
-prml-generic-asset = { version = "3.0.0", default-features = false, path = "../../../prml/generic-asset"}
 
 [build-dependencies]
 substrate-wasm-builder = { version = "4.0.0", path = "../../../utils/wasm-builder" }
@@ -162,7 +161,6 @@ std = [
 	"log/std",
 	"frame-try-runtime/std",
 	"prml-attestation/std",
-	"prml-generic-asset/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -200,7 +198,6 @@ runtime-benchmarks = [
 	"frame-system-benchmarking",
 	"hex-literal",
 	"prml-attestation/runtime-benchmarks",
-	"prml-generic-asset/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -46,7 +46,6 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
-pub use prml_generic_asset::AssetInfo;
 use sp_api::impl_runtime_apis;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_core::{
@@ -990,13 +989,6 @@ impl prml_attestation::Config for Runtime {
 	type WeightInfo = ();
 }
 
-impl prml_generic_asset::Config for Runtime {
-	type AssetId = AssetId;
-	type Balance = Balance;
-	type Event = Event;
-	type WeightInfo = ();
-}
-
 impl pallet_mmr::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"mmr";
 	type Hashing = <Runtime as frame_system::Config>::Hashing;
@@ -1118,7 +1110,6 @@ construct_runtime!(
 		Lottery: pallet_lottery::{Module, Call, Storage, Event<T>},
 		Gilt: pallet_gilt::{Module, Call, Storage, Event<T>, Config},
 		Attestation: prml_attestation::{Module, Call, Storage, Event<T>},
-		GenericAsset: prml_generic_asset::{Module, Call, Storage, Event<T>}
 	}
 );
 
@@ -1468,7 +1459,6 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_utility, Utility);
 			add_benchmark!(params, batches, pallet_vesting, Vesting);
 			add_benchmark!(params, batches, prml_attestation, Attestation);
-			add_benchmark!(params, batches, prml_generic_asset, GenericAsset);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -90,7 +90,7 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = ();
+	type AccountData = AccountData;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
@@ -101,6 +101,7 @@ impl Config for Test {
 	type Balance = u64;
 	type AssetId = u32;
 	type Event = Event;
+	type AccountStore = System;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
This minimally addresses #181. 
The reason for removing generic asset from Plug's runtime in this PR is that pallet_balances there overlaps with pallet_generic_asset and causes a conflict in this functionality. However pallet_generic_asset in its current implmentation cannot fully replace pallet_balances. As we had added the generic asset to Plug's runtime only for the sake of benchmarking, we can let cennznet do the benchmarking as in CENNZnet generic_asset works okay with all the other modules there.