### PR TITLE
Implement existential deposit for generic asset

### DIFF
--- a/prml/generic-asset/src/impls.rs
+++ b/prml/generic-asset/src/impls.rs
@@ -106,7 +106,7 @@ impl<T: Config> MultiCurrencyAccounting for Module<T> {
 		dest: &T::AccountId,
 		currency: Option<T::AssetId>,
 		value: Self::Balance,
-		_ex: ExistenceRequirement, // no existential deposit policy for generic asset
+		req: ExistenceRequirement,
 	) -> DispatchResult {
 		if value.is_zero() {
 			return Ok(());
@@ -116,6 +116,7 @@ impl<T: Config> MultiCurrencyAccounting for Module<T> {
 			transactor,
 			dest,
 			value,
+			req,
 		)
 	}
 

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -815,6 +815,7 @@ impl<T: Config> Module<T> {
 		AssetMeta::<T>::iter().collect()
 	}
 
+	/// Return true if the specified asset of `who` is considered dust (insignificant).
 	fn is_dust(asset_id: T::AssetId, who: &T::AccountId) -> bool {
 		let existential_deposit = AssetMeta::<T>::get(asset_id).existential_deposit();
 		// If for an asset, there is enough deposit above the defined existential deposit, it will not
@@ -825,6 +826,7 @@ impl<T: Config> Module<T> {
 			&& Self::locks(who).is_empty()
 	}
 
+	/// Try to mutate account of `who` in the account store based on `is_dust` for the specified asset.
 	fn try_mutate_account(asset_id: T::AssetId, who: &T::AccountId, is_dust: bool) -> Option<AccountData<T::AssetId>> {
 		T::AccountStore::try_mutate_exists(who, |maybe_account| {
 			match maybe_account {
@@ -863,7 +865,7 @@ impl<T: Config> Module<T> {
 	}
 
 	/// Mutate an account to some new value, or delete it entirely according to existence requirement
-	/// Return true if the account is mutated or false if it's deleted and thus got a zero balance.
+	/// Return true if the account is mutated or false if it's deleted.
 	fn try_mutate_account_with_dust(
 		asset_id: T::AssetId,
 		who: &T::AccountId,
@@ -892,6 +894,7 @@ impl<T: Config> Module<T> {
 		true
 	}
 
+	/// Set both `free_balance` and `reserved_balance` in one go meaning updating the account store once
 	fn set_balances(asset_id: T::AssetId, who: &T::AccountId, free_balance: T::Balance, reserved_balance: T::Balance) {
 		let _ = Self::try_mutate_account_with_dust(
 			asset_id,
@@ -904,8 +907,8 @@ impl<T: Config> Module<T> {
 		);
 	}
 
-	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
-	/// the caller will do this.
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance unless the account is
+	/// purged in which case it would only create and drop the imbalances for the purged stage.
 	fn set_reserved_balance(asset_id: T::AssetId, who: &T::AccountId, balance: T::Balance) {
 		let _ = Self::try_mutate_account_with_dust(
 			asset_id,
@@ -917,8 +920,8 @@ impl<T: Config> Module<T> {
 		);
 	}
 
-	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
-	/// the caller will do this.
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. unless the account is
+	/// purged in which case it would only create and drop the imbalances for the purged stage.
 	fn set_free_balance(asset_id: T::AssetId, who: &T::AccountId, free_balance: T::Balance) {
 		let _ = Self::try_mutate_account_with_dust(
 			asset_id,

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -220,7 +220,7 @@ pub trait Config: frame_system::Config {
 	/// The system event type
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
 
-	/// The means of storing the balances of an account.
+	/// The means of storing account data for account ids.
 	type AccountStore: StoredMap<Self::AccountId, AccountData<Self::AssetId>>;
 
 	/// The treasury account for clearing up dusts.

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -195,6 +195,7 @@ pub struct AccountData<AssetId: Ord> {
 
 impl<AssetId: AtLeast32BitUnsigned + Copy> AccountData<AssetId> {
 	/// Return true if the account should be kept in the account store.
+	#[allow(dead_code)]
 	fn should_exist(&self) -> bool {
 		!self.existing_assets.is_empty()
 	}
@@ -851,7 +852,7 @@ impl<T: Config> Module<T> {
 		// be considered a dust asset. Also any reservation or locks on the asset would mean the asset
 		// should be kept for the clearance of those operations and thus is not dust.
 		<FreeBalance<T>>::get(asset_id, who) < existential_deposit
-			&& <ReservedBalance<T>>::get(asset_id, who) == Zero::zero()
+			&& <ReservedBalance<T>>::get(asset_id, who).is_zero()
 			&& Self::locks(who).is_empty()
 	}
 
@@ -880,11 +881,12 @@ impl<T: Config> Module<T> {
 			<Result<_, &'static str>>::Ok(maybe_account.clone())
 		});
 
-		if asset_is_dust && !T::AccountStore::get(who).should_exist() {
-			// This is just an attempt to remove the account.
-			// Account store might still keep it if there are consumers for this account.
-			let _ = T::AccountStore::remove(who);
-		}
+		// TODO Enable the following logic after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// if asset_is_dust && !T::AccountStore::get(who).should_exist() {
+		// 	// This is just an attempt to remove the account.
+		// 	// Account store might still keep it if there are consumers for this account.
+		// 	let _ = T::AccountStore::remove(who);
+		// }
 	}
 
 	/// Remove an asset for an account and pass a non-zero imbalance to dust imbalance handler.

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -914,8 +914,8 @@ impl<T: Config> Module<T> {
 		);
 	}
 
-	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance unless the account is
-	/// purged in which case it would only create and drop the imbalances for the purged stage.
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+	/// the caller will do this.
 	fn set_reserved_balance(asset_id: T::AssetId, who: &T::AccountId, balance: T::Balance) {
 		Self::call_with_dust_check(
 			asset_id,
@@ -927,8 +927,8 @@ impl<T: Config> Module<T> {
 		);
 	}
 
-	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. unless the account is
-	/// purged in which case it would only create and drop the imbalances for the purged stage.
+	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
+	/// the caller will do this.
 	fn set_free_balance(asset_id: T::AssetId, who: &T::AccountId, free_balance: T::Balance) {
 		Self::call_with_dust_check(
 			asset_id,

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -502,7 +502,7 @@ decl_event! {
 		Minted(AssetId, AccountId, Balance),
 		/// Asset burned (asset_id, account, amount).
 		Burned(AssetId, AccountId, Balance),
-		/// Account has been deleted due to having below existential deposits
+		/// Asset balance storage has been reclaimed due to falling below the existential deposit
 		Purged(AssetId, AccountId, Balance),
 	}
 }

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -850,8 +850,8 @@ impl<T: Config> Module<T> {
 			match maybe_account {
 				Some(k) => {
 					if asset_is_dust {
-						k.existing_assets.remove(&asset_id);
 						if !k.is_persistent() {
+							k.existing_assets.remove(&asset_id);
 							Self::purge(asset_id, who);
 						}
 						if !k.should_exist() {

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -500,7 +500,7 @@ decl_event! {
 		/// Asset burned (asset_id, account, amount).
 		Burned(AssetId, AccountId, Balance),
 		/// Asset balance storage has been reclaimed due to falling below the existential deposit
-		Purged(AssetId, AccountId, Balance),
+		DustReclaimed(AssetId, AccountId, Balance),
 	}
 }
 

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -748,7 +748,10 @@ impl<T: Config> Module<T> {
 		let original_free_balance = Self::free_balance(asset_id, beneficiary);
 		let new_free_balance = original_free_balance + slash;
 		let new_reserve_balance = b - slash;
-		Self::set_balances(asset_id, who, new_free_balance, new_reserve_balance);
+
+		Self::set_free_balance(asset_id, beneficiary, new_free_balance);
+		Self::set_reserved_balance(asset_id, who, new_reserve_balance);
+
 		Ok(amount - slash)
 	}
 

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -29,7 +29,7 @@ use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
 	ModuleId,
 };
-use sp_std::{marker::PhantomData, mem};
+use sp_std::mem;
 
 // test accounts
 pub const ALICE: u64 = 1;
@@ -101,8 +101,8 @@ impl frame_system::Config for Test {
 parameter_types! {
 	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
 }
-pub struct TransferImbalanceToTreasury<T>(PhantomData<T>);
-impl OnUnbalanced<NegativeImbalance<Test>> for TransferImbalanceToTreasury<Test> {
+pub struct TransferImbalanceToTreasury;
+impl OnUnbalanced<NegativeImbalance<Test>> for TransferImbalanceToTreasury {
 	fn on_nonzero_unbalanced(imbalance: NegativeImbalance<Test>) {
 		let treasury_account_id = TreasuryModuleId::get().into_account();
 		let treasury_balance = GenericAsset::free_balance(imbalance.asset_id(), &treasury_account_id);
@@ -120,7 +120,7 @@ impl Config for Test {
 	type AssetId = u32;
 	type Event = Event;
 	type AccountStore = System;
-	type OnDustImbalance = TransferImbalanceToTreasury<Self>;
+	type OnDustImbalance = TransferImbalanceToTreasury;
 	type WeightInfo = ();
 }
 

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -104,10 +104,12 @@ parameter_types! {
 pub struct TransferImbalanceToTreasury<T>(PhantomData<T>);
 impl OnUnbalanced<NegativeImbalance<Test>> for TransferImbalanceToTreasury<Test> {
 	fn on_nonzero_unbalanced(imbalance: NegativeImbalance<Test>) {
+		let treasury_account_id = TreasuryModuleId::get().into_account();
+		let treasury_balance = GenericAsset::free_balance(imbalance.asset_id(), &treasury_account_id);
 		GenericAsset::set_free_balance(
 			imbalance.asset_id(),
 			&TreasuryModuleId::get().into_account(),
-			imbalance.amount(),
+			treasury_balance + imbalance.amount(),
 		);
 		mem::forget(imbalance);
 	}

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -46,11 +46,12 @@ pub const TEST1_ASSET_ID: u32 = 16003;
 pub const TEST2_ASSET_ID: u32 = 16004;
 // default next asset id
 pub const ASSET_ID: u32 = 1000;
-
 // initial issuance for creating new asset
 pub const INITIAL_ISSUANCE: u64 = 1000;
-// iniital balance for seting free balance
+// initial balance for setting free balance
 pub const INITIAL_BALANCE: u64 = 100;
+// lock identifier
+pub const ID_1: LockIdentifier = *b"1       ";
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -90,7 +91,7 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = AccountData;
+	type AccountData = AccountData<u32>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -26,6 +26,7 @@ use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	ModuleId,
 };
 
 use super::*;
@@ -98,11 +99,15 @@ impl frame_system::Config for Test {
 	type SS58Prefix = ();
 }
 
+parameter_types! {
+	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
+}
 impl Config for Test {
 	type Balance = u64;
 	type AssetId = u32;
 	type Event = Event;
 	type AccountStore = System;
+	type TreasuryModuleId = TreasuryModuleId;
 	type WeightInfo = ();
 }
 

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -108,7 +108,7 @@ impl OnUnbalanced<NegativeImbalance<Test>> for TransferImbalanceToTreasury<Test>
 		let treasury_balance = GenericAsset::free_balance(imbalance.asset_id(), &treasury_account_id);
 		GenericAsset::set_free_balance(
 			imbalance.asset_id(),
-			&TreasuryModuleId::get().into_account(),
+			&treasury_account_id,
 			treasury_balance + imbalance.amount(),
 		);
 		mem::forget(imbalance);

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -222,7 +222,10 @@ fn transfer_extrinsic_allows_death() {
 			INITIAL_BALANCE
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
-		assert!(!System::account_exists(&BOB));
+
+		// TODO Enable the following check after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// assert!(!System::account_exists(&BOB));
+
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -277,7 +280,10 @@ fn transfer_with_allow_death_existential_requirement() {
 			ExistenceRequirement::AllowDeath
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
-		assert!(!System::account_exists(&BOB));
+
+		// TODO Enable the following check after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// assert!(!System::account_exists(&BOB));
+
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -352,7 +358,8 @@ fn balance_falls_below_a_non_default_existential_deposit() {
 		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert_ok!(GenericAsset::transfer(Origin::signed(BOB), ASSET_ID, ALICE, 1));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
-		assert!(!System::account_exists(&BOB));
+		// TODO Enable the following check after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 	});
 }
@@ -387,7 +394,10 @@ fn purge_happens_per_asset() {
 			INITIAL_BALANCE
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
-		assert!(!System::account_exists(&BOB));
+
+		// TODO Enable the following check after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// assert!(!System::account_exists(&BOB));
+
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<ReservedBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<Locks<Test>>::contains_key(&BOB));
@@ -430,7 +440,10 @@ fn purged_dust_move_to_treasury() {
 
 		// Test purge has happened
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
-		assert!(!System::account_exists(&BOB));
+
+		// TODO Enable the following check after https://github.com/plugblockchain/plug-blockchain/issues/191
+		// assert!(!System::account_exists(&BOB));
+
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID + 1, &BOB));
 

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -24,7 +24,7 @@ use super::*;
 use crate::mock::{
 	new_test_ext_with_balance, new_test_ext_with_default, new_test_ext_with_next_asset_id,
 	new_test_ext_with_permissions, Event as TestEvent, GenericAsset, NegativeImbalanceOf, Origin, PositiveImbalanceOf,
-	System, Test, ALICE, ASSET_ID, BOB, CHARLIE, INITIAL_BALANCE, INITIAL_ISSUANCE, SPENDING_ASSET_ID,
+	System, Test, ALICE, ASSET_ID, BOB, CHARLIE, ID_1, INITIAL_BALANCE, INITIAL_ISSUANCE, SPENDING_ASSET_ID,
 	STAKING_ASSET_ID, TEST1_ASSET_ID, TEST2_ASSET_ID,
 };
 use crate::CheckedImbalance;
@@ -201,6 +201,194 @@ fn transferring_less_than_one_unit_should_fail() {
 			GenericAsset::transfer(Origin::signed(ALICE), ASSET_ID, BOB, 0),
 			Error::<Test>::ZeroAmount
 		);
+	});
+}
+
+#[test]
+fn transfer_extrinsic_allows_death() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			STAKING_ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn transfer_with_keep_existential_requirement() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(StakingAssetCurrency::<Test>::transfer(
+			&BOB,
+			&ALICE,
+			INITIAL_BALANCE,
+			ExistenceRequirement::KeepAlive
+		));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn transfer_with_allow_death_existential_requirement() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(StakingAssetCurrency::<Test>::transfer(
+			&BOB,
+			&ALICE,
+			INITIAL_BALANCE,
+			ExistenceRequirement::AllowDeath
+		));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn endowed_accounts_persist_even_below_existential_deposit() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		assert!(<Test as Config>::AccountStore::get(&ALICE).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(ALICE),
+			STAKING_ASSET_ID,
+			BOB,
+			INITIAL_BALANCE
+		));
+		assert!(<Test as Config>::AccountStore::get(&ALICE).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &ALICE));
+	});
+}
+
+#[test]
+fn any_significant_balance_prevent_purging() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		assert_ok!(GenericAsset::create(
+			Origin::root(),
+			ALICE,
+			asset_options(PermissionLatest::new(ALICE)),
+			AssetInfo::default()
+		));
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			STAKING_ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn any_reserved_balance_prevent_purging() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		GenericAsset::set_reserved_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			STAKING_ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn any_locked_balance_prevent_purging() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		let lock_amount = 3;
+		let asset_info = AssetInfo::new(b"TST1".to_vec(), 1, 11);
+		assert_ok!(GenericAsset::create(
+			Origin::root(),
+			ALICE,
+			asset_options(PermissionLatest::new(ALICE)),
+			asset_info
+		));
+		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
+		GenericAsset::set_lock(ID_1, &BOB, lock_amount, WithdrawReasons::TRANSACTION_PAYMENT);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE - lock_amount
+		));
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn balance_falls_below_a_non_default_existential_deposit() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		let asset_info = AssetInfo::new(b"TST1".to_vec(), 1, 11);
+		assert_ok!(GenericAsset::create(
+			Origin::root(),
+			ALICE,
+			asset_options(PermissionLatest::new(ALICE)),
+			asset_info.clone()
+		));
+		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE - asset_info.existential_deposit()
+		));
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
+		assert_ok!(GenericAsset::transfer(Origin::signed(BOB), ASSET_ID, ALICE, 1));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
+	});
+}
+
+#[test]
+fn purge_deletes_storage_for_all_assets() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		assert_ok!(GenericAsset::create(
+			Origin::root(),
+			ALICE,
+			asset_options(PermissionLatest::new(ALICE)),
+			AssetInfo::default()
+		));
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			STAKING_ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
+		assert!(!<ReservedBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+		assert!(!<ReservedBalance<Test>>::contains_key(ASSET_ID, &BOB));
+		assert!(!<Locks<Test>>::contains_key(&BOB));
 	});
 }
 
@@ -1370,7 +1558,8 @@ fn query_pre_existing_asset_info() {
 			GenericAsset::registered_assets(),
 			vec![
 				(TEST1_ASSET_ID, AssetInfo::new(b"TST1".to_vec(), 1, 3)),
-				(TEST2_ASSET_ID, AssetInfo::new(b"TST 2".to_vec(), 2, 5))
+				(TEST2_ASSET_ID, AssetInfo::new(b"TST 2".to_vec(), 2, 5)),
+				(STAKING_ASSET_ID, AssetInfo::default()),
 			]
 		);
 	});

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -24,11 +24,13 @@ use super::*;
 use crate::mock::{
 	new_test_ext_with_balance, new_test_ext_with_default, new_test_ext_with_next_asset_id,
 	new_test_ext_with_permissions, Event as TestEvent, GenericAsset, NegativeImbalanceOf, Origin, PositiveImbalanceOf,
-	System, Test, ALICE, ASSET_ID, BOB, CHARLIE, ID_1, INITIAL_BALANCE, INITIAL_ISSUANCE, SPENDING_ASSET_ID,
-	STAKING_ASSET_ID, TEST1_ASSET_ID, TEST2_ASSET_ID,
+	System, Test, TreasuryModuleId, ALICE, ASSET_ID, BOB, CHARLIE, ID_1, INITIAL_BALANCE, INITIAL_ISSUANCE,
+	SPENDING_ASSET_ID, STAKING_ASSET_ID, TEST1_ASSET_ID, TEST2_ASSET_ID,
 };
 use crate::CheckedImbalance;
 use frame_support::{assert_noop, assert_ok, traits::Imbalance};
+use sp_runtime::traits::AccountIdConversion;
+
 fn asset_options(permissions: PermissionLatest<u64>) -> AssetOptions<u64, u64> {
 	AssetOptions {
 		initial_issuance: INITIAL_ISSUANCE,
@@ -411,7 +413,7 @@ fn purged_dust_move_to_treasury() {
 		assert_eq!(GenericAsset::total_issuance(ASSET_ID), INITIAL_ISSUANCE);
 		assert_eq!(GenericAsset::total_issuance(ASSET_ID + 1), INITIAL_ISSUANCE);
 
-		let treasury_account_id = <Test as Config>::TreasuryModuleId::get().into_account();
+		let treasury_account_id = TreasuryModuleId::get().into_account();
 		assert_eq!(
 			GenericAsset::free_balance(ASSET_ID, &treasury_account_id),
 			asset_info_1.existential_deposit() - 1

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -208,14 +208,14 @@ fn transferring_less_than_one_unit_should_fail() {
 fn transfer_extrinsic_allows_death() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
 			ALICE,
 			INITIAL_BALANCE
 		));
-		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -224,14 +224,14 @@ fn transfer_extrinsic_allows_death() {
 fn transfer_with_keep_existential_requirement() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(StakingAssetCurrency::<Test>::transfer(
 			&BOB,
 			&ALICE,
 			INITIAL_BALANCE,
 			ExistenceRequirement::KeepAlive
 		));
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -240,14 +240,14 @@ fn transfer_with_keep_existential_requirement() {
 fn transfer_with_allow_death_existential_requirement() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(StakingAssetCurrency::<Test>::transfer(
 			&BOB,
 			&ALICE,
 			INITIAL_BALANCE,
 			ExistenceRequirement::AllowDeath
 		));
-		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -255,14 +255,14 @@ fn transfer_with_allow_death_existential_requirement() {
 #[test]
 fn endowed_accounts_persist_even_below_existential_deposit() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
-		assert!(<Test as Config>::AccountStore::get(&ALICE).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&ALICE).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(ALICE),
 			STAKING_ASSET_ID,
 			BOB,
 			INITIAL_BALANCE
 		));
-		assert!(<Test as Config>::AccountStore::get(&ALICE).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&ALICE).should_exist());
 		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &ALICE));
 	});
 }
@@ -272,14 +272,14 @@ fn any_reserved_balance_prevent_purging() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_reserved_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
 			ALICE,
 			INITIAL_BALANCE
 		));
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -297,14 +297,14 @@ fn any_locked_balance_prevent_purging() {
 		));
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_lock(ID_1, &BOB, lock_amount, WithdrawReasons::TRANSACTION_PAYMENT);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			ASSET_ID,
 			ALICE,
 			INITIAL_BALANCE - lock_amount
 		));
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 	});
 }
@@ -320,17 +320,17 @@ fn balance_falls_below_a_non_default_existential_deposit() {
 			asset_info.clone()
 		));
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			ASSET_ID,
 			ALICE,
 			INITIAL_BALANCE - asset_info.existential_deposit()
 		));
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert_ok!(GenericAsset::transfer(Origin::signed(BOB), ASSET_ID, ALICE, 1));
-		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 	});
 }
@@ -346,14 +346,14 @@ fn purge_happens_per_asset() {
 		));
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
 			ALICE,
 			INITIAL_BALANCE
 		));
-		assert!(<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 		assert!(!<ReservedBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 		assert_ok!(GenericAsset::transfer(
@@ -362,7 +362,7 @@ fn purge_happens_per_asset() {
 			ALICE,
 			INITIAL_BALANCE
 		));
-		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<ReservedBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<Locks<Test>>::contains_key(&BOB));
@@ -404,7 +404,7 @@ fn purged_dust_move_to_treasury() {
 		));
 
 		// Test purge has happened
-		assert!(!<Test as Config>::AccountStore::get(&BOB).is_significant());
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID + 1, &BOB));
 

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -255,21 +255,6 @@ fn transfer_with_allow_death_existential_requirement() {
 }
 
 #[test]
-fn endowed_accounts_persist_even_below_existential_deposit() {
-	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
-		assert!(<Test as Config>::AccountStore::get(&ALICE).should_exist());
-		assert_ok!(GenericAsset::transfer(
-			Origin::signed(ALICE),
-			STAKING_ASSET_ID,
-			BOB,
-			INITIAL_BALANCE
-		));
-		assert!(<Test as Config>::AccountStore::get(&ALICE).should_exist());
-		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &ALICE));
-	});
-}
-
-#[test]
 fn any_reserved_balance_prevent_purging() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -231,7 +231,7 @@ fn transfer_extrinsic_allows_death() {
 }
 
 #[test]
-fn an_account_with_a_consumer_should_persist_in_system_even_when_ga_not_providing_it() {
+fn an_account_with_a_consumer_should_persist_in_system() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -225,6 +225,25 @@ fn transfer_extrinsic_allows_death() {
 }
 
 #[test]
+fn an_account_with_a_consumer_should_persist_in_system_even_when_ga_not_providing_it() {
+	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
+		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
+		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
+		assert_ok!(System::inc_consumers(&BOB));
+		assert_ok!(GenericAsset::transfer(
+			Origin::signed(BOB),
+			STAKING_ASSET_ID,
+			ALICE,
+			INITIAL_BALANCE
+		));
+		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
+		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
+	});
+}
+
+#[test]
 fn transfer_with_keep_existential_requirement() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -211,6 +211,7 @@ fn transfer_extrinsic_allows_death() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
@@ -218,6 +219,7 @@ fn transfer_extrinsic_allows_death() {
 			INITIAL_BALANCE
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -227,6 +229,7 @@ fn transfer_with_keep_existential_requirement() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(StakingAssetCurrency::<Test>::transfer(
 			&BOB,
 			&ALICE,
@@ -234,6 +237,7 @@ fn transfer_with_keep_existential_requirement() {
 			ExistenceRequirement::KeepAlive
 		));
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -243,6 +247,7 @@ fn transfer_with_allow_death_existential_requirement() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(StakingAssetCurrency::<Test>::transfer(
 			&BOB,
 			&ALICE,
@@ -250,6 +255,7 @@ fn transfer_with_allow_death_existential_requirement() {
 			ExistenceRequirement::AllowDeath
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -260,6 +266,7 @@ fn any_reserved_balance_prevent_purging() {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_reserved_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
@@ -267,6 +274,7 @@ fn any_reserved_balance_prevent_purging() {
 			INITIAL_BALANCE
 		));
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert!(<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 	});
 }
@@ -285,6 +293,7 @@ fn any_locked_balance_prevent_purging() {
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_lock(ID_1, &BOB, lock_amount, WithdrawReasons::TRANSACTION_PAYMENT);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			ASSET_ID,
@@ -292,6 +301,7 @@ fn any_locked_balance_prevent_purging() {
 			INITIAL_BALANCE - lock_amount
 		));
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 	});
 }
@@ -308,6 +318,7 @@ fn balance_falls_below_a_non_default_existential_deposit() {
 		));
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			ASSET_ID,
@@ -315,9 +326,11 @@ fn balance_falls_below_a_non_default_existential_deposit() {
 			INITIAL_BALANCE - asset_info.existential_deposit()
 		));
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert!(<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert_ok!(GenericAsset::transfer(Origin::signed(BOB), ASSET_ID, ALICE, 1));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 	});
 }
@@ -334,6 +347,7 @@ fn purge_happens_per_asset() {
 		GenericAsset::set_free_balance(STAKING_ASSET_ID, &BOB, INITIAL_BALANCE);
 		GenericAsset::set_free_balance(ASSET_ID, &BOB, INITIAL_BALANCE);
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert_ok!(GenericAsset::transfer(
 			Origin::signed(BOB),
 			STAKING_ASSET_ID,
@@ -341,6 +355,7 @@ fn purge_happens_per_asset() {
 			INITIAL_BALANCE
 		));
 		assert!(<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 		assert!(!<ReservedBalance<Test>>::contains_key(STAKING_ASSET_ID, &BOB));
 		assert_ok!(GenericAsset::transfer(
@@ -350,6 +365,7 @@ fn purge_happens_per_asset() {
 			INITIAL_BALANCE
 		));
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<ReservedBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<Locks<Test>>::contains_key(&BOB));
@@ -392,6 +408,7 @@ fn purged_dust_move_to_treasury() {
 
 		// Test purge has happened
 		assert!(!<Test as Config>::AccountStore::get(&BOB).should_exist());
+		assert!(!System::account_exists(&BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID, &BOB));
 		assert!(!<FreeBalance<Test>>::contains_key(ASSET_ID + 1, &BOB));
 


### PR DESCRIPTION
Closes #183. Keeps trace of significant assets for account ids and claim dust balances if the policy says so. Also add a migration logic for updating the newly added account store from the current storage and purging dust balances on runtime upgrade.
