### PR TITLE
Fix minimum_balance of MultiCurrencyAccounting and Currency for GA

### DIFF
--- a/prml/generic-asset/src/impls.rs
+++ b/prml/generic-asset/src/impls.rs
@@ -33,6 +33,10 @@ impl<T: Config> MultiCurrencyAccounting for Module<T> {
 	type PositiveImbalance = PositiveImbalance<T>;
 	type NegativeImbalance = NegativeImbalance<T>;
 
+	fn minimum_balance(currency: Option<T::AssetId>) -> Self::Balance {
+		<Module<T>>::asset_meta(currency.unwrap_or_else(|| Self::DefaultCurrencyId::asset_id())).existential_deposit()
+	}
+
 	fn total_balance(who: &T::AccountId, currency: Option<T::AssetId>) -> Self::Balance {
 		<Module<T>>::total_balance(currency.unwrap_or_else(|| Self::DefaultCurrencyId::asset_id()), who)
 	}
@@ -146,14 +150,28 @@ impl<T: Config> MultiCurrencyAccounting for Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext_with_balance, new_test_ext_with_default, GenericAsset, Test};
+	use crate::mock::{
+		new_test_ext_with_balance, new_test_ext_with_default, GenericAsset, Test, STAKING_ASSET_ID, TEST1_ASSET_ID,
+		TEST2_ASSET_ID,
+	};
 	use frame_support::assert_noop;
 	use sp_runtime::traits::Zero;
 
 	#[test]
 	fn multi_accounting_minimum_balance() {
 		new_test_ext_with_default().execute_with(|| {
-			assert!(<GenericAsset as MultiCurrencyAccounting>::minimum_balance().is_zero());
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::minimum_balance(Some(TEST1_ASSET_ID)),
+				3
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::minimum_balance(Some(TEST2_ASSET_ID)),
+				5
+			);
+			assert_eq!(
+				<GenericAsset as MultiCurrencyAccounting>::minimum_balance(Some(STAKING_ASSET_ID)),
+				1
+			);
 		});
 	}
 

--- a/prml/generic-asset/src/impls.rs
+++ b/prml/generic-asset/src/impls.rs
@@ -172,6 +172,8 @@ mod tests {
 				<GenericAsset as MultiCurrencyAccounting>::minimum_balance(Some(STAKING_ASSET_ID)),
 				1
 			);
+			// When currency is None, the minimum balance for the default currency will be returned.
+			assert_eq!(<GenericAsset as MultiCurrencyAccounting>::minimum_balance(None), 1);
 		});
 	}
 

--- a/prml/generic-asset/src/lib.rs
+++ b/prml/generic-asset/src/lib.rs
@@ -1083,7 +1083,7 @@ where
 	}
 
 	fn minimum_balance() -> Self::Balance {
-		Zero::zero()
+		AssetMeta::<T>::get(U::asset_id()).existential_deposit()
 	}
 
 	fn transfer(

--- a/prml/generic-asset/src/mock.rs
+++ b/prml/generic-asset/src/mock.rs
@@ -171,5 +171,5 @@ pub(crate) fn new_test_ext_with_next_asset_id(next_asset_id: u32) -> sp_io::Test
 }
 
 pub(crate) fn new_test_ext_with_permissions(permissions: Vec<(u32, u64)>) -> sp_io::TestExternalities {
-	new_test_ext(vec![0], vec![], 0, permissions, ASSET_ID)
+	new_test_ext(vec![0], vec![], 0, permissions, TEST2_ASSET_ID + 1)
 }

--- a/prml/generic-asset/src/tests.rs
+++ b/prml/generic-asset/src/tests.rs
@@ -409,6 +409,30 @@ fn balance_falls_below_a_non_default_existential_deposit() {
 }
 
 #[test]
+fn minimum_balance_is_existential_deposit() {
+	new_test_ext_with_permissions(vec![(STAKING_ASSET_ID, ALICE), (SPENDING_ASSET_ID, ALICE)]).execute_with(|| {
+		let stk_min = 11u64;
+		let spd_min = 17u64;
+		let staking_asset_info = AssetInfo::new(b"STK".to_vec(), 1, stk_min);
+		let spending_asset_info = AssetInfo::new(b"SPD".to_vec(), 2, spd_min);
+		assert_ok!(GenericAsset::create_asset(
+			Some(STAKING_ASSET_ID),
+			Some(ALICE),
+			asset_options(PermissionLatest::new(ALICE)),
+			staking_asset_info
+		));
+		assert_ok!(GenericAsset::create_asset(
+			Some(SPENDING_ASSET_ID),
+			Some(ALICE),
+			asset_options(PermissionLatest::new(ALICE)),
+			spending_asset_info
+		));
+		assert_eq!(StakingAssetCurrency::<Test>::minimum_balance(), stk_min);
+		assert_eq!(SpendingAssetCurrency::<Test>::minimum_balance(), spd_min);
+	});
+}
+
+#[test]
 fn purge_happens_per_asset() {
 	new_test_ext_with_balance(STAKING_ASSET_ID, ALICE, INITIAL_BALANCE).execute_with(|| {
 		assert_ok!(GenericAsset::create(

--- a/prml/support/src/lib.rs
+++ b/prml/support/src/lib.rs
@@ -24,7 +24,7 @@
 // are used interchangeably as they make more sense in certain contexts.
 use frame_support::traits::{ExistenceRequirement, Imbalance, SignedImbalance, WithdrawReasons};
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Saturating, Zero},
+	traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Saturating},
 	DispatchError, DispatchResult,
 };
 use sp_std::{fmt::Debug, result};
@@ -61,9 +61,7 @@ pub trait MultiCurrencyAccounting {
 
 	/// The minimum balance any single account may have. This is equivalent to the `Balances` module's
 	/// `ExistentialDeposit`.
-	fn minimum_balance() -> Self::Balance {
-		Zero::zero()
-	}
+	fn minimum_balance(currency: Option<Self::CurrencyId>) -> Self::Balance;
 
 	/// The combined balance (free + reserved) of `who` for the given `currency`.
 	fn total_balance(who: &Self::AccountId, currency: Option<Self::CurrencyId>) -> Self::Balance;


### PR DESCRIPTION
It should return the existential deposit of the relevant asset. One test is added and another test is amended so they maintain this requirement.