### PR TITLE
For a plug node, replace pallet_balances with generic_asset.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,7 +3918,6 @@ dependencies = [
  "node-rpc",
  "node-runtime",
  "pallet-authority-discovery",
- "pallet-balances",
  "pallet-contracts",
  "pallet-grandpa",
  "pallet-im-online",
@@ -3929,6 +3928,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "platforms",
+ "prml-generic-asset",
  "rand 0.7.3",
  "regex",
  "sc-authority-discovery",
@@ -3990,7 +3990,6 @@ dependencies = [
  "node-primitives",
  "node-runtime",
  "node-testing",
- "pallet-balances",
  "pallet-contracts",
  "pallet-grandpa",
  "pallet-im-online",
@@ -4000,6 +3999,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-treasury",
  "parity-scale-codec",
+ "prml-generic-asset",
  "sc-executor",
  "sp-application-crypto",
  "sp-consensus-babe",
@@ -4107,7 +4107,6 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
- "pallet-balances",
  "pallet-bounties",
  "pallet-collective",
  "pallet-contracts",
@@ -4146,6 +4145,8 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "prml-attestation",
+ "prml-generic-asset",
+ "prml-support",
  "serde",
  "sp-api",
  "sp-authority-discovery",
@@ -4252,7 +4253,6 @@ dependencies = [
  "node-executor",
  "node-primitives",
  "node-runtime",
- "pallet-balances",
  "pallet-contracts",
  "pallet-grandpa",
  "pallet-indices",
@@ -4263,6 +4263,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-treasury",
  "parity-scale-codec",
+ "prml-generic-asset",
  "sc-block-builder",
  "sc-cli",
  "sc-client-api",
@@ -6035,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "prml-support"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -82,13 +82,13 @@ pallet-indices = { version = "3.0.0", path = "../../../frame/indices" }
 pallet-timestamp = { version = "3.0.0", default-features = false, path = "../../../frame/timestamp" }
 pallet-contracts = { version = "3.0.0", path = "../../../frame/contracts" }
 frame-system = { version = "3.0.0", path = "../../../frame/system" }
-pallet-balances = { version = "3.0.0", path = "../../../frame/balances" }
 pallet-transaction-payment = { version = "3.0.0", path = "../../../frame/transaction-payment" }
 frame-support = { version = "3.0.0", default-features = false, path = "../../../frame/support" }
 pallet-im-online = { version = "3.0.0", default-features = false, path = "../../../frame/im-online" }
 pallet-authority-discovery = { version = "3.0.0", path = "../../../frame/authority-discovery" }
 pallet-staking = { version = "3.0.0", path = "../../../frame/staking" }
 pallet-grandpa = { version = "3.0.0", path = "../../../frame/grandpa" }
+prml-generic-asset = { version = "3.0.0", path = "../../../prml/generic-asset" }
 
 # node-specific dependencies
 node-runtime = { version = "2.0.0", path = "../runtime" }

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -22,19 +22,20 @@ use sc_chain_spec::ChainSpecExtension;
 use sp_core::{Pair, Public, crypto::UncheckedInto, sr25519};
 use serde::{Serialize, Deserialize};
 use node_runtime::{
-	AuthorityDiscoveryConfig, BabeConfig, BalancesConfig, ContractsConfig, CouncilConfig,
+	AuthorityDiscoveryConfig, BabeConfig, GenericAssetConfig, ContractsConfig, CouncilConfig,
 	DemocracyConfig,GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus,
 	StakingConfig, ElectionsConfig, IndicesConfig, SocietyConfig, SudoConfig, SystemConfig,
 	TechnicalCommitteeConfig, wasm_binary_unwrap,
 };
 use node_runtime::Block;
-use node_runtime::constants::currency::*;
+use node_runtime::constants::{asset::*, currency::*};
 use sc_service::ChainType;
 use hex_literal::hex;
 use sc_telemetry::TelemetryEndpoints;
 use grandpa_primitives::{AuthorityId as GrandpaId};
 use sp_consensus_babe::{AuthorityId as BabeId};
 use pallet_im_online::sr25519::{AuthorityId as ImOnlineId};
+use prml_generic_asset::AssetInfo;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_runtime::{Perbill, traits::{Verify, IdentifyAccount}};
 
@@ -250,13 +251,25 @@ pub fn testnet_genesis(
 			code: wasm_binary_unwrap().to_vec(),
 			changes_trie_config: Default::default(),
 		}),
-		pallet_balances: Some(BalancesConfig {
-			balances: endowed_accounts.iter().cloned()
-				.map(|x| (x, ENDOWMENT))
-				.collect()
-		}),
 		pallet_indices: Some(IndicesConfig {
 			indices: vec![],
+		}),
+		prml_generic_asset: Some(GenericAssetConfig {
+			assets: vec![CENNZ_ASSET_ID, CENTRAPAY_ASSET_ID],
+			// Grant root key full permissions (mint,burn,update) on the following assets
+			permissions: vec![
+				(CENNZ_ASSET_ID, endowed_accounts[0].clone()),
+				(CENTRAPAY_ASSET_ID, endowed_accounts[0].clone()),
+			],
+			initial_balance: ENDOWMENT,
+			endowed_accounts: endowed_accounts.clone(),
+			next_asset_id: NEXT_ASSET_ID,
+			staking_asset_id: STAKING_ASSET_ID,
+			spending_asset_id: SPENDING_ASSET_ID,
+			asset_meta: vec![
+				(CENNZ_ASSET_ID, AssetInfo::new(b"CENNZ".to_vec(), 4, 1)),
+				(CENTRAPAY_ASSET_ID, AssetInfo::new(b"CPAY".to_vec(), 4, 1)),
+			],
 		}),
 		pallet_session: Some(SessionConfig {
 			keys: initial_authorities.iter().map(|x| {

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -255,11 +255,10 @@ pub fn testnet_genesis(
 			indices: vec![],
 		}),
 		prml_generic_asset: Some(GenericAssetConfig {
-			assets: vec![CENNZ_ASSET_ID, CENTRAPAY_ASSET_ID],
+			assets: vec![PLUG_ASSET_ID,],
 			// Grant root key full permissions (mint,burn,update) on the following assets
 			permissions: vec![
-				(CENNZ_ASSET_ID, endowed_accounts[0].clone()),
-				(CENTRAPAY_ASSET_ID, endowed_accounts[0].clone()),
+				(PLUG_ASSET_ID, endowed_accounts[0].clone()),
 			],
 			initial_balance: ENDOWMENT,
 			endowed_accounts: endowed_accounts.clone(),
@@ -267,8 +266,7 @@ pub fn testnet_genesis(
 			staking_asset_id: STAKING_ASSET_ID,
 			spending_asset_id: SPENDING_ASSET_ID,
 			asset_meta: vec![
-				(CENNZ_ASSET_ID, AssetInfo::new(b"CENNZ".to_vec(), 4, 1)),
-				(CENTRAPAY_ASSET_ID, AssetInfo::new(b"CPAY".to_vec(), 4, 1)),
+				(PLUG_ASSET_ID, AssetInfo::new(b"PLUG".to_vec(), 4, 1)),
 			],
 		}),
 		pallet_session: Some(SessionConfig {

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -487,7 +487,7 @@ mod tests {
 		Environment, Proposer, BlockImportParams, BlockOrigin, ForkChoiceStrategy, BlockImport,
 	};
 	use node_primitives::{Block, DigestItem, Signature};
-	use node_runtime::{BalancesCall, Call, UncheckedExtrinsic, Address};
+	use node_runtime::{Call, GenericAsset, GenericAssetCall, UncheckedExtrinsic, Address};
 	use node_runtime::constants::{currency::CENTS, time::SLOT_DURATION};
 	use codec::Encode;
 	use sp_core::{
@@ -650,7 +650,7 @@ mod tests {
 			},
 			|service, _| {
 				let amount = 5 * CENTS;
-				let to: Address = AccountPublic::from(bob.public()).into_account().into();
+				let to = AccountPublic::from(bob.public()).into_account();
 				let from: Address = AccountPublic::from(charlie.public()).into_account().into();
 				let genesis_hash = service.client().block_hash(0).unwrap().unwrap();
 				let best_block_id = BlockId::number(service.client().chain_info().best_number);
@@ -660,7 +660,11 @@ mod tests {
 				};
 				let signer = charlie.clone();
 
-				let function = Call::Balances(BalancesCall::transfer(to.into(), amount));
+				let function = Call::GenericAsset(GenericAssetCall::transfer(
+					GenericAsset::spending_asset_id(),
+					to,
+					amount,
+				));
 
 				let check_spec_version = frame_system::CheckSpecVersion::new();
 				let check_tx_version = frame_system::CheckTxVersion::new();

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -29,7 +29,6 @@ criterion = "0.3.0"
 frame-support = { version = "3.0.0", path = "../../../frame/support" }
 frame-system = { version = "3.0.0", path = "../../../frame/system" }
 node-testing = { version = "2.0.0", path = "../testing" }
-pallet-balances = { version = "3.0.0", path = "../../../frame/balances" }
 pallet-contracts = { version = "3.0.0", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "3.0.0", path = "../../../frame/grandpa" }
 pallet-im-online = { version = "3.0.0", path = "../../../frame/im-online" }
@@ -38,6 +37,7 @@ pallet-session = { version = "3.0.0", path = "../../../frame/session" }
 pallet-timestamp = { version = "3.0.0", path = "../../../frame/timestamp" }
 pallet-transaction-payment = { version = "3.0.0", path = "../../../frame/transaction-payment" }
 pallet-treasury = { version = "3.0.0", path = "../../../frame/treasury" }
+prml-generic-asset = { version = "3.0.0", path = "../../../prml/generic-asset" }
 sp-application-crypto = { version = "3.0.0", path = "../../../primitives/application-crypto" }
 sp-consensus-babe = { version = "0.9.0", path = "../../../primitives/consensus/babe" }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }

--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -20,7 +20,8 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use node_executor::Executor;
 use node_primitives::{BlockNumber, Hash};
 use node_runtime::{
-	Block, BuildStorage, Call, CheckedExtrinsic, GenesisConfig, Header, UncheckedExtrinsic,
+	Block, BuildStorage, Call, CheckedExtrinsic, GenericAsset, GenericAssetCall, GenesisConfig,
+	Header, UncheckedExtrinsic,
 };
 use node_runtime::constants::currency::*;
 use node_testing::keyring::*;
@@ -153,7 +154,11 @@ fn test_blocks(genesis_config: &GenesisConfig, executor: &NativeExecutor<Executo
 	block1_extrinsics.extend((0..20).map(|i| {
 		CheckedExtrinsic {
 			signed: Some((alice(), signed_extra(i, 0))),
-			function: Call::Balances(pallet_balances::Call::transfer(bob().into(), 1 * DOLLARS)),
+			function: Call::GenericAsset(GenericAssetCall::transfer(
+				GenericAsset::spending_asset_id(),
+				bob(),
+				1 * DOLLARS,
+			)),
 		}
 	}));
 	let block1 = construct_block(

--- a/bin/node/executor/tests/common.rs
+++ b/bin/node/executor/tests/common.rs
@@ -39,7 +39,8 @@ use sc_executor::error::Result;
 
 use node_executor::Executor;
 use node_runtime::{
-	Header, Block, UncheckedExtrinsic, CheckedExtrinsic, Runtime, BuildStorage,
+	Header, Block, UncheckedExtrinsic, CheckedExtrinsic, GenericAsset, Runtime,
+	BuildStorage,
 	constants::currency::*,
 };
 use node_primitives::{Hash, BlockNumber};
@@ -88,8 +89,8 @@ pub fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
 	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
 }
 
-pub fn default_transfer_call() -> pallet_balances::Call<Runtime> {
-	pallet_balances::Call::transfer::<Runtime>(bob().into(), 69 * DOLLARS)
+pub fn default_transfer_call() -> prml_generic_asset::Call<Runtime> {
+	prml_generic_asset::Call::transfer::<Runtime>(GenericAsset::spending_asset_id(), bob(), 69 * DOLLARS)
 }
 
 pub fn from_block_number(n: u32) -> Header {

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 use node_runtime::{
-	Executive, Indices, Runtime, UncheckedExtrinsic,
+	Executive, GenericAsset, Indices, Runtime, UncheckedExtrinsic,
 };
 use sp_application_crypto::AppKey;
 use sp_core::{
@@ -92,7 +92,11 @@ fn should_submit_signed_transaction() {
 	t.execute_with(|| {
 		let results = Signer::<Runtime, TestAuthorityId>::all_accounts()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 
 		let len = results.len();
@@ -124,7 +128,11 @@ fn should_submit_signed_twice_from_the_same_account() {
 	t.execute_with(|| {
 		let result = Signer::<Runtime, TestAuthorityId>::any_account()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 
 		assert!(result.is_some());
@@ -133,7 +141,11 @@ fn should_submit_signed_twice_from_the_same_account() {
 		// submit another one from the same account. The nonce should be incremented.
 		let result = Signer::<Runtime, TestAuthorityId>::any_account()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 
 		assert!(result.is_some());
@@ -174,7 +186,11 @@ fn should_submit_signed_twice_from_all_accounts() {
 	t.execute_with(|| {
 		let results = Signer::<Runtime, TestAuthorityId>::all_accounts()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 
 		let len = results.len();
@@ -185,7 +201,11 @@ fn should_submit_signed_twice_from_all_accounts() {
 		// submit another one from the same account. The nonce should be incremented.
 		let results = Signer::<Runtime, TestAuthorityId>::all_accounts()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 
 		let len = results.len();
@@ -234,7 +254,11 @@ fn submitted_transaction_should_be_valid() {
 	t.execute_with(|| {
 		let results = Signer::<Runtime, TestAuthorityId>::all_accounts()
 			.send_signed_transaction(|_| {
-				pallet_balances::Call::transfer(Default::default(), Default::default())
+				prml_generic_asset::Call::transfer(
+					GenericAsset::spending_asset_id(),
+					Default::default(),
+					Default::default(),
+				)
 			});
 		let len = results.len();
 		assert_eq!(len, 1);
@@ -251,7 +275,8 @@ fn submitted_transaction_should_be_valid() {
 		// add balance to the account
 		let author = extrinsic.signature.clone().unwrap().0;
 		let address = Indices::lookup(author).unwrap();
-		let data = pallet_balances::AccountData { free: 5_000_000_000_000, ..Default::default() };
+		// TODO the account should have 5_000_000_000_000 of spending asset free
+		let data = prml_generic_asset::AccountData::<u32>::default();
 		let account = frame_system::AccountInfo { nonce: 0, consumers: 0, providers: 0, data };
 		<frame_system::Account<Runtime>>::insert(&address, account);
 

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -49,7 +49,6 @@ pallet-assets = { version = "3.0.0", default-features = false, path = "../../../
 pallet-authority-discovery = { version = "3.0.0", default-features = false, path = "../../../frame/authority-discovery" }
 pallet-authorship = { version = "3.0.0", default-features = false, path = "../../../frame/authorship" }
 pallet-babe = { version = "3.0.0", default-features = false, path = "../../../frame/babe" }
-pallet-balances = { version = "3.0.0", default-features = false, path = "../../../frame/balances" }
 pallet-bounties = { version = "3.0.0", default-features = false, path = "../../../frame/bounties" }
 pallet-collective = { version = "3.0.0", default-features = false, path = "../../../frame/collective" }
 pallet-contracts = { version = "3.0.0", default-features = false, path = "../../../frame/contracts" }
@@ -87,6 +86,8 @@ pallet-transaction-payment = { version = "3.0.0", default-features = false, path
 pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
 pallet-vesting = { version = "3.0.0", default-features = false, path = "../../../frame/vesting" }
 prml-attestation = { version = "3.0.0", default-features = false, path = "../../../prml/attestation" }
+prml-support = { version = "3.0.0", default-features = false, path = "../../../prml/support" }
+prml-generic-asset = { version = "3.0.0", default-features = false, path = "../../../prml/generic-asset" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "4.0.0", path = "../../../utils/wasm-builder" }
@@ -104,7 +105,6 @@ std = [
 	"pallet-authorship/std",
 	"sp-consensus-babe/std",
 	"pallet-babe/std",
-	"pallet-balances/std",
 	"pallet-bounties/std",
 	"sp-block-builder/std",
 	"codec/std",
@@ -161,6 +161,8 @@ std = [
 	"log/std",
 	"frame-try-runtime/std",
 	"prml-attestation/std",
+	"prml-support/std",
+	"prml-generic-asset/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -170,7 +172,6 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-babe/runtime-benchmarks",
-	"pallet-balances/runtime-benchmarks",
 	"pallet-bounties/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
 	"pallet-contracts/runtime-benchmarks",
@@ -198,6 +199,7 @@ runtime-benchmarks = [
 	"frame-system-benchmarking",
 	"hex-literal",
 	"prml-attestation/runtime-benchmarks",
+	"prml-generic-asset/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",
@@ -207,7 +209,6 @@ try-runtime = [
 	"pallet-authority-discovery/try-runtime",
 	"pallet-authorship/try-runtime",
 	"pallet-babe/try-runtime",
-	"pallet-balances/try-runtime",
 	"pallet-bounties/try-runtime",
 	"pallet-collective/try-runtime",
 	"pallet-contracts/try-runtime",

--- a/bin/node/runtime/src/constants.rs
+++ b/bin/node/runtime/src/constants.rs
@@ -21,13 +21,11 @@
 pub mod asset {
 	use node_primitives::AssetId;
 
-	pub const CENNZ_ASSET_ID: AssetId = 16000;
-	pub const CENTRAPAY_ASSET_ID: AssetId = 16001;
 	pub const PLUG_ASSET_ID: AssetId = 16002;
 	pub const NEXT_ASSET_ID: AssetId = 17000;
 
-	pub const STAKING_ASSET_ID: AssetId = CENNZ_ASSET_ID;
-	pub const SPENDING_ASSET_ID: AssetId = CENTRAPAY_ASSET_ID;
+	pub const STAKING_ASSET_ID: AssetId = PLUG_ASSET_ID;
+	pub const SPENDING_ASSET_ID: AssetId = PLUG_ASSET_ID;
 }
 
 /// Money matters.

--- a/bin/node/runtime/src/constants.rs
+++ b/bin/node/runtime/src/constants.rs
@@ -17,6 +17,19 @@
 
 //! A set of constant values used in substrate runtime.
 
+/// TestNet Asset IDs.
+pub mod asset {
+	use node_primitives::AssetId;
+
+	pub const CENNZ_ASSET_ID: AssetId = 16000;
+	pub const CENTRAPAY_ASSET_ID: AssetId = 16001;
+	pub const PLUG_ASSET_ID: AssetId = 16002;
+	pub const NEXT_ASSET_ID: AssetId = 17000;
+
+	pub const STAKING_ASSET_ID: AssetId = CENNZ_ASSET_ID;
+	pub const SPENDING_ASSET_ID: AssetId = CENTRAPAY_ASSET_ID;
+}
+
 /// Money matters.
 pub mod currency {
 	use node_primitives::Balance;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use codec::{Decode, Encode};
 use frame_support::traits::InstanceFilter;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Currency, Imbalance, KeyOwnerProofSystem, LockIdentifier, OnUnbalanced, Randomness, U128CurrencyToVote},
+	traits::{KeyOwnerProofSystem, LockIdentifier, Randomness, U128CurrencyToVote},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
@@ -46,6 +46,7 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
+use prml_generic_asset::{SpendingAssetCurrency, StakingAssetCurrency};
 use sp_api::impl_runtime_apis;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_core::{
@@ -72,15 +73,15 @@ use static_assertions::const_assert;
 #[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;
 #[cfg(any(feature = "std", test))]
-pub use pallet_balances::Call as BalancesCall;
-#[cfg(any(feature = "std", test))]
 pub use pallet_staking::StakerStatus;
+#[cfg(any(feature = "std", test))]
+pub use prml_generic_asset::Call as GenericAssetCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
-use impls::Author;
+use impls::{DealWithFees, TransferImbalanceToTreasury};
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -122,24 +123,6 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion {
 		runtime_version: VERSION,
 		can_author_with: Default::default(),
-	}
-}
-
-type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
-
-pub struct DealWithFees;
-impl OnUnbalanced<NegativeImbalance> for DealWithFees {
-	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
-		if let Some(fees) = fees_then_tips.next() {
-			// for fees, 80% to treasury, 20% to author
-			let mut split = fees.ration(80, 20);
-			if let Some(tips) = fees_then_tips.next() {
-				// for tips, if any, 80% to treasury, 20% to author (though this can be anything)
-				tips.ration_merge_into(80, 20, &mut split);
-			}
-			Treasury::on_unbalanced(split.0);
-			Author::on_unbalanced(split.1);
-		}
 	}
 }
 
@@ -198,7 +181,7 @@ impl frame_system::Config for Runtime {
 	type BlockHashCount = BlockHashCount;
 	type Version = Version;
 	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<Balance>;
+	type AccountData = prml_generic_asset::AccountData<AssetId>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = frame_system::weights::SubstrateWeight<Runtime>;
@@ -222,7 +205,7 @@ parameter_types! {
 impl pallet_multisig::Config for Runtime {
 	type Event = Event;
 	type Call = Call;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
 	type MaxSignatories = MaxSignatories;
@@ -259,7 +242,7 @@ impl InstanceFilter<Call> for ProxyType {
 			ProxyType::Any => true,
 			ProxyType::NonTransfer => !matches!(
 				c,
-				Call::Balances(..)
+				Call::GenericAsset(..)
 					| Call::Vesting(pallet_vesting::Call::vested_transfer(..))
 					| Call::Indices(pallet_indices::Call::transfer(..))
 			),
@@ -288,7 +271,7 @@ impl InstanceFilter<Call> for ProxyType {
 impl pallet_proxy::Config for Runtime {
 	type Event = Event;
 	type Call = Call;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type ProxyType = ProxyType;
 	type ProxyDepositBase = ProxyDepositBase;
 	type ProxyDepositFactor = ProxyDepositFactor;
@@ -348,7 +331,7 @@ parameter_types! {
 
 impl pallet_indices::Config for Runtime {
 	type AccountIndex = AccountIndex;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type Deposit = IndexDeposit;
 	type Event = Event;
 	type WeightInfo = pallet_indices::weights::SubstrateWeight<Runtime>;
@@ -361,16 +344,6 @@ parameter_types! {
 	pub const MaxLocks: u32 = 50;
 }
 
-impl pallet_balances::Config for Runtime {
-	type MaxLocks = MaxLocks;
-	type Balance = Balance;
-	type DustRemoval = ();
-	type Event = Event;
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = frame_system::Module<Runtime>;
-	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
-}
-
 parameter_types! {
 	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
@@ -379,7 +352,7 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-	type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees>;
+	type OnChargeTransaction = CurrencyAdapter<SpendingAssetCurrency<Runtime>, DealWithFees>;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
@@ -466,7 +439,7 @@ parameter_types! {
 }
 
 impl pallet_staking::Config for Runtime {
-	type Currency = Balances;
+	type Currency = StakingAssetCurrency<Self>;
 	type UnixTime = Timestamp;
 	type CurrencyToVote = U128CurrencyToVote;
 	type RewardRemainder = Treasury;
@@ -520,7 +493,7 @@ parameter_types! {
 
 impl pallet_election_provider_multi_phase::Config for Runtime {
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
 	type SolutionImprovementThreshold = MinSolutionScoreBump;
@@ -552,7 +525,7 @@ parameter_types! {
 impl pallet_democracy::Config for Runtime {
 	type Proposal = Call;
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type EnactmentPeriod = EnactmentPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
@@ -630,7 +603,7 @@ const_assert!(DesiredMembers::get() <= CouncilMaxMembers::get());
 impl pallet_elections_phragmen::Config for Runtime {
 	type Event = Event;
 	type ModuleId = ElectionsPhragmenModuleId;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type ChangeMembers = Council;
 	// NOTE: this implies that council's genesis members cannot be set directly and must come from
 	// this module.
@@ -701,7 +674,7 @@ parameter_types! {
 
 impl pallet_treasury::Config for Runtime {
 	type ModuleId = TreasuryModuleId;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type ApproveOrigin = EnsureOneOf<
 		AccountId,
 		EnsureRoot<AccountId>,
@@ -774,7 +747,7 @@ parameter_types! {
 impl pallet_contracts::Config for Runtime {
 	type Time = Timestamp;
 	type Randomness = RandomnessCollectiveFlip;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type Event = Event;
 	type RentPayment = ();
 	type SignedClaimHandicap = SignedClaimHandicap;
@@ -914,7 +887,7 @@ parameter_types! {
 
 impl pallet_identity::Config for Runtime {
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type BasicDeposit = BasicDeposit;
 	type FieldDeposit = FieldDeposit;
 	type SubAccountDeposit = SubAccountDeposit;
@@ -937,7 +910,7 @@ parameter_types! {
 impl pallet_recovery::Config for Runtime {
 	type Event = Event;
 	type Call = Call;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type ConfigDepositBase = ConfigDepositBase;
 	type FriendDepositFactor = FriendDepositFactor;
 	type MaxFriends = MaxFriends;
@@ -958,7 +931,7 @@ parameter_types! {
 impl pallet_society::Config for Runtime {
 	type Event = Event;
 	type ModuleId = SocietyModuleId;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type Randomness = RandomnessCollectiveFlip;
 	type CandidateDeposit = CandidateDeposit;
 	type WrongSideDeduction = WrongSideDeduction;
@@ -978,7 +951,7 @@ parameter_types! {
 
 impl pallet_vesting::Config for Runtime {
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type BlockNumberToBalance = ConvertInto;
 	type MinVestedTransfer = MinVestedTransfer;
 	type WeightInfo = pallet_vesting::weights::SubstrateWeight<Runtime>;
@@ -986,6 +959,15 @@ impl pallet_vesting::Config for Runtime {
 
 impl prml_attestation::Config for Runtime {
 	type Event = Event;
+	type WeightInfo = ();
+}
+
+impl prml_generic_asset::Config for Runtime {
+	type AssetId = AssetId;
+	type Balance = Balance;
+	type Event = Event;
+	type AccountStore = System;
+	type OnDustImbalance = TransferImbalanceToTreasury;
 	type WeightInfo = ();
 }
 
@@ -1008,7 +990,7 @@ impl pallet_lottery::Config for Runtime {
 	type ModuleId = LotteryModuleId;
 	type Call = Call;
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type Randomness = RandomnessCollectiveFlip;
 	type ManagerOrigin = EnsureRoot<AccountId>;
 	type MaxCalls = MaxCalls;
@@ -1029,7 +1011,7 @@ impl pallet_assets::Config for Runtime {
 	type Event = Event;
 	type Balance = u64;
 	type AssetId = u32;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type ForceOrigin = EnsureRoot<AccountId>;
 	type AssetDepositBase = AssetDepositBase;
 	type AssetDepositPerZombie = AssetDepositPerZombie;
@@ -1051,7 +1033,7 @@ parameter_types! {
 
 impl pallet_gilt::Config for Runtime {
 	type Event = Event;
-	type Currency = Balances;
+	type Currency = SpendingAssetCurrency<Self>;
 	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
 	type Deficit = ();
 	type Surplus = ();
@@ -1077,7 +1059,6 @@ construct_runtime!(
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
 		Authorship: pallet_authorship::{Module, Call, Storage, Inherent},
 		Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},
-		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 		TransactionPayment: pallet_transaction_payment::{Module, Storage},
 		ElectionProviderMultiPhase: pallet_election_provider_multi_phase::{Module, Call, Storage, Event<T>, ValidateUnsigned},
 		Staking: pallet_staking::{Module, Call, Config<T>, Storage, Event<T>, ValidateUnsigned},
@@ -1110,6 +1091,7 @@ construct_runtime!(
 		Lottery: pallet_lottery::{Module, Call, Storage, Event<T>},
 		Gilt: pallet_gilt::{Module, Call, Storage, Event<T>, Config},
 		Attestation: prml_attestation::{Module, Call, Storage, Event<T>},
+		GenericAsset: prml_generic_asset::{Module, Call, Storage, Event<T>, Config<T>},
 	}
 );
 
@@ -1432,7 +1414,6 @@ impl_runtime_apis! {
 
 			add_benchmark!(params, batches, pallet_assets, Assets);
 			add_benchmark!(params, batches, pallet_babe, Babe);
-			add_benchmark!(params, batches, pallet_balances, Balances);
 			add_benchmark!(params, batches, pallet_bounties, Bounties);
 			add_benchmark!(params, batches, pallet_collective, Council);
 			add_benchmark!(params, batches, pallet_contracts, Contracts);
@@ -1459,6 +1440,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_utility, Utility);
 			add_benchmark!(params, batches, pallet_vesting, Vesting);
 			add_benchmark!(params, batches, prml_attestation, Attestation);
+			add_benchmark!(params, batches, prml_generic_asset, GenericAsset);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1387,11 +1387,9 @@ impl_runtime_apis! {
 			// issues. To get around that, we separated the Session benchmarks into its own crate,
 			// which is why we need these two lines below.
 			use pallet_session_benchmarking::Module as SessionBench;
-			use pallet_offences_benchmarking::Module as OffencesBench;
 			use frame_system_benchmarking::Module as SystemBench;
 
 			impl pallet_session_benchmarking::Config for Runtime {}
-			impl pallet_offences_benchmarking::Config for Runtime {}
 			impl frame_system_benchmarking::Config for Runtime {}
 
 			let whitelist: Vec<TrackedStorageKey> = vec![
@@ -1428,7 +1426,6 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_lottery, Lottery);
 			add_benchmark!(params, batches, pallet_mmr, Mmr);
 			add_benchmark!(params, batches, pallet_multisig, Multisig);
-			add_benchmark!(params, batches, pallet_offences, OffencesBench::<Runtime>);
 			add_benchmark!(params, batches, pallet_proxy, Proxy);
 			add_benchmark!(params, batches, pallet_scheduler, Scheduler);
 			add_benchmark!(params, batches, pallet_session, SessionBench::<Runtime>);

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1061,6 +1061,7 @@ construct_runtime!(
 		Indices: pallet_indices::{Module, Call, Storage, Config<T>, Event<T>},
 		TransactionPayment: pallet_transaction_payment::{Module, Storage},
 		ElectionProviderMultiPhase: pallet_election_provider_multi_phase::{Module, Call, Storage, Event<T>, ValidateUnsigned},
+		GenericAsset: prml_generic_asset::{Module, Call, Storage, Event<T>, Config<T>},
 		Staking: pallet_staking::{Module, Call, Config<T>, Storage, Event<T>, ValidateUnsigned},
 		Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
 		Democracy: pallet_democracy::{Module, Call, Storage, Config, Event<T>},
@@ -1091,7 +1092,6 @@ construct_runtime!(
 		Lottery: pallet_lottery::{Module, Call, Storage, Event<T>},
 		Gilt: pallet_gilt::{Module, Call, Storage, Event<T>, Config},
 		Attestation: prml_attestation::{Module, Call, Storage, Event<T>},
-		GenericAsset: prml_generic_asset::{Module, Call, Storage, Event<T>, Config<T>},
 	}
 );
 

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -13,7 +13,6 @@ publish = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-pallet-balances = { version = "3.0.0", path = "../../../frame/balances" }
 sc-service = { version = "0.9.0", features = ["test-helpers", "db"],  path = "../../../client/service" }
 sc-client-db = { version = "0.9.0", path = "../../../client/db/", features = ["kvdb-rocksdb", "parity-db"] }
 sc-client-api = { version = "3.0.0", path = "../../../client/api/" }
@@ -45,6 +44,7 @@ sp-block-builder = { version = "3.0.0", path = "../../../primitives/block-builde
 sc-block-builder = { version = "0.9.0", path = "../../../client/block-builder" }
 sp-inherents = { version = "3.0.0", path = "../../../primitives/inherents" }
 sp-blockchain = { version = "3.0.0", path = "../../../primitives/blockchain" }
+prml-generic-asset = { version = "3.0.0", path = "../../../prml/generic-asset" }
 log = "0.4.8"
 tempfile = "3.1.0"
 fs_extra = "1"

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -46,7 +46,8 @@ use node_runtime::{
 	UncheckedExtrinsic,
 	MinimumPeriod,
 	SystemCall,
-	BalancesCall,
+	GenericAsset,
+	GenericAssetCall,
 	AccountId,
 	Signature,
 };
@@ -315,17 +316,19 @@ impl<'a> Iterator for BlockContentIterator<'a> {
 				signed: Some((sender, signed_extra(0, node_runtime::ExistentialDeposit::get() + 1))),
 				function: match self.content.block_type {
 					BlockType::RandomTransfersKeepAlive => {
-						Call::Balances(
-							BalancesCall::transfer_keep_alive(
-								sp_runtime::MultiAddress::Id(receiver),
+						Call::GenericAsset(
+							GenericAssetCall::transfer_keep_alive(
+								GenericAsset::spending_asset_id(),
+								receiver,
 								node_runtime::ExistentialDeposit::get() + 1,
 							)
 						)
 					},
 					BlockType::RandomTransfersReaping => {
-						Call::Balances(
-							BalancesCall::transfer(
-								sp_runtime::MultiAddress::Id(receiver),
+						Call::GenericAsset(
+							GenericAssetCall::transfer(
+								GenericAsset::spending_asset_id(),
+								receiver,
 								// Transfer so that ending balance would be 1 less than existential deposit
 								// so that we kill the sender account.
 								100*DOLLARS - (node_runtime::ExistentialDeposit::get() - 1),

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -59,17 +59,16 @@ pub fn config_endowed(
 			indices: vec![],
 		}),
 		prml_generic_asset: Some(GenericAssetConfig {
-			assets: vec![CENNZ_ASSET_ID, CENTRAPAY_ASSET_ID],
+			assets: vec![PLUG_ASSET_ID,],
 			// Grant root key full permissions (mint,burn,update) on the following assets
-			permissions: vec![(CENNZ_ASSET_ID, alice()), (CENTRAPAY_ASSET_ID, alice())],
+			permissions: vec![(PLUG_ASSET_ID, alice()),],
 			initial_balance: 100 * DOLLARS,
 			endowed_accounts: endowed,
 			next_asset_id: NEXT_ASSET_ID,
 			staking_asset_id: STAKING_ASSET_ID,
 			spending_asset_id: SPENDING_ASSET_ID,
 			asset_meta: vec![
-				(CENNZ_ASSET_ID, AssetInfo::new(b"CENNZ".to_vec(), 4, 1)),
-				(CENTRAPAY_ASSET_ID, AssetInfo::new(b"CPAY".to_vec(), 4, 1)),
+				(PLUG_ASSET_ID, AssetInfo::new(b"PLUG".to_vec(), 4, 1)),
 			],
 		}),
 		pallet_session: Some(SessionConfig {

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -21,11 +21,12 @@
 use crate::keyring::*;
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use node_runtime::{
-	GenesisConfig, BalancesConfig, SessionConfig, StakingConfig, SystemConfig,
+	GenesisConfig, GenericAssetConfig, SessionConfig, StakingConfig, SystemConfig,
 	GrandpaConfig, IndicesConfig, ContractsConfig, SocietyConfig, wasm_binary_unwrap,
 	AccountId, StakerStatus,
 };
-use node_runtime::constants::currency::*;
+use node_runtime::constants::{asset::*, currency::*};
+use prml_generic_asset::AssetInfo;
 use sp_core::ChangesTrieConfiguration;
 use sp_runtime::Perbill;
 
@@ -42,18 +43,9 @@ pub fn config_endowed(
 	extra_endowed: Vec<AccountId>,
 ) -> GenesisConfig {
 
-	let mut endowed = vec![
-		(alice(), 111 * DOLLARS),
-		(bob(), 100 * DOLLARS),
-		(charlie(), 100_000_000 * DOLLARS),
-		(dave(), 111 * DOLLARS),
-		(eve(), 101 * DOLLARS),
-		(ferdie(), 100 * DOLLARS),
-	];
+	let mut endowed = vec![alice(), bob(), charlie(), dave(), eve(), ferdie()];
 
-	endowed.extend(
-		extra_endowed.into_iter().map(|endowed| (endowed, 100*DOLLARS))
-	);
+	endowed.extend(extra_endowed.into_iter());
 
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -66,8 +58,19 @@ pub fn config_endowed(
 		pallet_indices: Some(IndicesConfig {
 			indices: vec![],
 		}),
-		pallet_balances: Some(BalancesConfig {
-			balances: endowed,
+		prml_generic_asset: Some(GenericAssetConfig {
+			assets: vec![CENNZ_ASSET_ID, CENTRAPAY_ASSET_ID],
+			// Grant root key full permissions (mint,burn,update) on the following assets
+			permissions: vec![(CENNZ_ASSET_ID, alice()), (CENTRAPAY_ASSET_ID, alice())],
+			initial_balance: 100 * DOLLARS,
+			endowed_accounts: endowed,
+			next_asset_id: NEXT_ASSET_ID,
+			staking_asset_id: STAKING_ASSET_ID,
+			spending_asset_id: SPENDING_ASSET_ID,
+			asset_meta: vec![
+				(CENNZ_ASSET_ID, AssetInfo::new(b"CENNZ".to_vec(), 4, 1)),
+				(CENTRAPAY_ASSET_ID, AssetInfo::new(b"CPAY".to_vec(), 4, 1)),
+			],
 		}),
 		pallet_session: Some(SessionConfig {
 			keys: vec![

--- a/prml/generic-asset/src/benchmarking.rs
+++ b/prml/generic-asset/src/benchmarking.rs
@@ -44,6 +44,22 @@ benchmarks! {
 		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &recipient), transfer_amount);
 	}
 
+	transfer_keep_alive {
+		let caller: T::AccountId = whitelisted_caller();
+
+		// spending asset id
+		let asset_id = GenericAsset::<T>::spending_asset_id();
+		let initial_balance = T::Balance::from(5_000_000u32);
+		GenericAsset::<T>::set_free_balance(asset_id, &caller, initial_balance);
+
+		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let transfer_amount = T::Balance::from(5_000_000u32);
+	}: transfer_keep_alive(RawOrigin::Signed(caller.clone()), asset_id, recipient.clone(), transfer_amount)
+	verify {
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &caller), Zero::zero());
+		assert_eq!(GenericAsset::<T>::free_balance(asset_id, &recipient), transfer_amount);
+	}
+
 	// Benchmark `burn`, GA's create comes from ROOT account. This always creates an asset.
 	// Mint some amount of new asset to an account and burn the asset from it.
 	burn {

--- a/prml/generic-asset/src/weights.rs
+++ b/prml/generic-asset/src/weights.rs
@@ -34,41 +34,44 @@ pub trait WeightInfo {
 
 impl WeightInfo for () {
 	fn transfer() -> Weight {
-		(155_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(203_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(8 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
 	}
 	fn transfer_keep_alive() -> Weight {
-		0
+		(156_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(8 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn burn() -> Weight {
-		(92_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
+		(95_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(6 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn create() -> Weight {
-		(77_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(1 as Weight))
+		(122_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
 			.saturating_add(DbWeight::get().writes(5 as Weight))
 	}
 	fn mint() -> Weight {
-		(92_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(126_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(7 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn update_asset_info() -> Weight {
-		(70_000_000 as Weight)
+		(48_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn update_permission() -> Weight {
-		(60_000_000 as Weight)
+		(42_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn create_reserved() -> Weight {
-		(87_000_000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
+		(131_000_000 as Weight)
+			.saturating_add(DbWeight::get().reads(7 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
 	}
 }
+

--- a/prml/generic-asset/src/weights.rs
+++ b/prml/generic-asset/src/weights.rs
@@ -27,6 +27,7 @@ pub trait WeightInfo {
 	fn create_reserved() -> Weight;
 	fn mint() -> Weight;
 	fn transfer() -> Weight;
+	fn transfer_keep_alive() -> Weight;
 	fn update_asset_info() -> Weight;
 	fn update_permission() -> Weight;
 }
@@ -36,6 +37,9 @@ impl WeightInfo for () {
 		(155_000_000 as Weight)
 			.saturating_add(DbWeight::get().reads(4 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+	fn transfer_keep_alive() -> Weight {
+		0
 	}
 	fn burn() -> Weight {
 		(92_000_000 as Weight)

--- a/prml/support/Cargo.toml
+++ b/prml/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prml-support"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
Replace pallet Balances with Generic Asset for a plug node and do another round of benchmarking generic asset. The command used to benchmark is:
`cargo run --release --features runtime-benchmarks -p node-cli -- benchmark --chain dev --steps 50 --repeat 2 --pallet prml_generic_asset --extrinsic "*" --raw --execution=wasm --wasm-execution=compiled --output generic_asset.rs`